### PR TITLE
feat: generate connecpy api from proto in package

### DIFF
--- a/protoc-gen-connecpy/generator/generator.go
+++ b/protoc-gen-connecpy/generator/generator.go
@@ -37,9 +37,12 @@ func Generate(r *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
 func GenerateConnecpyFile(fd *descriptor.FileDescriptorProto) (*plugin.CodeGeneratorResponse_File, error) {
 	name := fd.GetName()
 
+	fileNameWithoutSuffix := strings.TrimSuffix(name, path.Ext(name))
+	moduleName := strings.Join(strings.Split(fileNameWithoutSuffix, "/"), ".")
+
 	vars := ConnecpyTemplateVariables{
 		FileName:              name,
-		FileNameWithoutSuffix: strings.TrimSuffix(name, path.Ext(name)),
+		ModuleName:            moduleName,
 	}
 
 	svcs := fd.GetService()

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -4,7 +4,7 @@ import "text/template"
 
 type ConnecpyTemplateVariables struct {
 	FileName              string
-	FileNameWithoutSuffix string
+	ModuleName            string
 	Services              []*ConnecpyService
 }
 
@@ -44,7 +44,7 @@ from connecpy.server import ConnecpyServer
 from connecpy.client import ConnecpyClient
 from connecpy.context import ServiceContext
 
-import {{.FileNameWithoutSuffix}}_pb2 as _pb2
+import {{.ModuleName}}_pb2 as _pb2
 
 {{range .Services}}
 class {{.Name}}Service(Protocol):{{- range .Methods }}


### PR DESCRIPTION
If proto files are organized in sub directories, the generated connecpy file import pb2 file in a wrong way.

For example, if the protos files are in the following directoies:
```
- apis
   - api.proto 
```

The generated api_connecpy.py will import api_pb2 by `import apis/api_pb2 as _pb2`, and it is illegal.

This PR will import api_pb2 in module way, which is `import apis.api_pb2 as _pb2`
