### PR TITLE
chore(generator): change the name of a generated service protocol class

### DIFF
--- a/example/haberdasher_connecpy.py
+++ b/example/haberdasher_connecpy.py
@@ -15,12 +15,12 @@ from connecpy.context import ServiceContext
 import haberdasher_pb2 as _pb2
 
 
-class HaberdasherService(Protocol):
+class Haberdasher(Protocol):
     async def MakeHat(self, req: _pb2.Size, ctx: ServiceContext) -> _pb2.Hat: ...
 
 
 class HaberdasherServer(ConnecpyServer):
-    def __init__(self, *, service: HaberdasherService, server_path_prefix=""):
+    def __init__(self, *, service: Haberdasher, server_path_prefix=""):
         super().__init__(service=service)
         self._prefix = f"{server_path_prefix}/i2y.connecpy.example.Haberdasher"
         self._endpoints = {

--- a/example/haberdasher_pb2.py
+++ b/example/haberdasher_pb2.py
@@ -3,7 +3,6 @@
 # source: haberdasher.proto
 # Protobuf Python Version: 4.25.1
 """Generated protocol buffer code."""
-
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
@@ -13,20 +12,20 @@ from google.protobuf.internal import builder as _builder
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x11haberdasher.proto\x12\x14i2y.connecpy.example">\n\x03Hat\x12\x0c\n\x04size\x18\x01 \x01(\x05\x12\r\n\x05\x63olor\x18\x02 \x01(\t\x12\x11\n\x04name\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_name"\x16\n\x04Size\x12\x0e\n\x06inches\x18\x01 \x01(\x05\x32O\n\x0bHaberdasher\x12@\n\x07MakeHat\x12\x1a.i2y.connecpy.example.Size\x1a\x19.i2y.connecpy.example.HatB\tZ\x07\x65xampleb\x06proto3'
-)
+
+
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11haberdasher.proto\x12\x14i2y.connecpy.example\">\n\x03Hat\x12\x0c\n\x04size\x18\x01 \x01(\x05\x12\r\n\x05\x63olor\x18\x02 \x01(\t\x12\x11\n\x04name\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_name\"\x16\n\x04Size\x12\x0e\n\x06inches\x18\x01 \x01(\x05\x32O\n\x0bHaberdasher\x12@\n\x07MakeHat\x12\x1a.i2y.connecpy.example.Size\x1a\x19.i2y.connecpy.example.HatB\tZ\x07\x65xampleb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "haberdasher_pb2", _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'haberdasher_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-    _globals["DESCRIPTOR"]._options = None
-    _globals["DESCRIPTOR"]._serialized_options = b"Z\007example"
-    _globals["_HAT"]._serialized_start = 43
-    _globals["_HAT"]._serialized_end = 105
-    _globals["_SIZE"]._serialized_start = 107
-    _globals["_SIZE"]._serialized_end = 129
-    _globals["_HABERDASHER"]._serialized_start = 131
-    _globals["_HABERDASHER"]._serialized_end = 210
+  _globals['DESCRIPTOR']._options = None
+  _globals['DESCRIPTOR']._serialized_options = b'Z\007example'
+  _globals['_HAT']._serialized_start=43
+  _globals['_HAT']._serialized_end=105
+  _globals['_SIZE']._serialized_start=107
+  _globals['_SIZE']._serialized_end=129
+  _globals['_HABERDASHER']._serialized_start=131
+  _globals['_HABERDASHER']._serialized_end=210
 # @@protoc_insertion_point(module_scope)

--- a/example/haberdasher_pb2.pyi
+++ b/example/haberdasher_pb2.pyi
@@ -12,12 +12,7 @@ class Hat(_message.Message):
     size: int
     color: str
     name: str
-    def __init__(
-        self,
-        size: _Optional[int] = ...,
-        color: _Optional[str] = ...,
-        name: _Optional[str] = ...,
-    ) -> None: ...
+    def __init__(self, size: _Optional[int] = ..., color: _Optional[str] = ..., name: _Optional[str] = ...) -> None: ...
 
 class Size(_message.Message):
     __slots__ = ("inches",)

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -47,13 +47,13 @@ from connecpy.context import ServiceContext
 import {{.ModuleName}}_pb2 as _pb2
 
 {{range .Services}}
-class {{.Name}}Service(Protocol):{{- range .Methods }}
+class {{.Name}}(Protocol):{{- range .Methods }}
     async def {{.Name}}(self, req: _pb2.{{.InputType}}, ctx: ServiceContext) -> _pb2.{{.OutputType}}: ...
 {{- end }}
 
 
 class {{.Name}}Server(ConnecpyServer):
-    def __init__(self, *, service: {{.Name}}Service, server_path_prefix=""):
+    def __init__(self, *, service: {{.Name}}, server_path_prefix=""):
         super().__init__(service=service)
         self._prefix = f"{server_path_prefix}/{{.ServiceURL}}"
         self._endpoints = { {{- range .Methods }}


### PR DESCRIPTION
## What
This PR changes the name of a generated service protocol class as the following:

original: `<Service Name>Service` Protocol
new:      `<Service Name>` Protocol

[This](https://github.com/i2y/connecpy/pull/5/files#diff-b1ebd8e6bde6512cc22899ce45289cd0b9605d7f8d9d41b5de5830032c68f530R18) is the actual example.

## Why
In Protocol Buffers definitions, a service often has the service postfix (e.g., `GreeterService`). In that case, if the protocol class name becomes `GreeterServiceService`, it appears awkward.