### PR TITLE
feat: add `serviceName` method to server class

### DIFF
--- a/example/haberdasher_connecpy.py
+++ b/example/haberdasher_connecpy.py
@@ -21,7 +21,7 @@ class Haberdasher(Protocol):
 
 class HaberdasherServer(ConnecpyServer):
     def __init__(self, *, service: Haberdasher, server_path_prefix=""):
-        super().__init__(service=service)
+        super().__init__()
         self._prefix = f"{server_path_prefix}/i2y.connecpy.example.Haberdasher"
         self._endpoints = {
             "MakeHat": Endpoint[_pb2.Size, _pb2.Hat](
@@ -32,6 +32,9 @@ class HaberdasherServer(ConnecpyServer):
                 output=_pb2.Hat,
             ),
         }
+
+    def serviceName(self):
+        return "i2y.connecpy.example.Haberdasher"
 
 
 class HaberdasherClient(ConnecpyClient):

--- a/example/haberdasher_pb2.py
+++ b/example/haberdasher_pb2.py
@@ -3,6 +3,7 @@
 # source: haberdasher.proto
 # Protobuf Python Version: 4.25.1
 """Generated protocol buffer code."""
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import symbol_database as _symbol_database
@@ -12,20 +13,20 @@ from google.protobuf.internal import builder as _builder
 _sym_db = _symbol_database.Default()
 
 
-
-
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11haberdasher.proto\x12\x14i2y.connecpy.example\">\n\x03Hat\x12\x0c\n\x04size\x18\x01 \x01(\x05\x12\r\n\x05\x63olor\x18\x02 \x01(\t\x12\x11\n\x04name\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_name\"\x16\n\x04Size\x12\x0e\n\x06inches\x18\x01 \x01(\x05\x32O\n\x0bHaberdasher\x12@\n\x07MakeHat\x12\x1a.i2y.connecpy.example.Size\x1a\x19.i2y.connecpy.example.HatB\tZ\x07\x65xampleb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
+    b'\n\x11haberdasher.proto\x12\x14i2y.connecpy.example">\n\x03Hat\x12\x0c\n\x04size\x18\x01 \x01(\x05\x12\r\n\x05\x63olor\x18\x02 \x01(\t\x12\x11\n\x04name\x18\x03 \x01(\tH\x00\x88\x01\x01\x42\x07\n\x05_name"\x16\n\x04Size\x12\x0e\n\x06inches\x18\x01 \x01(\x05\x32O\n\x0bHaberdasher\x12@\n\x07MakeHat\x12\x1a.i2y.connecpy.example.Size\x1a\x19.i2y.connecpy.example.HatB\tZ\x07\x65xampleb\x06proto3'
+)
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'haberdasher_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "haberdasher_pb2", _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
-  _globals['DESCRIPTOR']._options = None
-  _globals['DESCRIPTOR']._serialized_options = b'Z\007example'
-  _globals['_HAT']._serialized_start=43
-  _globals['_HAT']._serialized_end=105
-  _globals['_SIZE']._serialized_start=107
-  _globals['_SIZE']._serialized_end=129
-  _globals['_HABERDASHER']._serialized_start=131
-  _globals['_HABERDASHER']._serialized_end=210
+    _globals["DESCRIPTOR"]._options = None
+    _globals["DESCRIPTOR"]._serialized_options = b"Z\007example"
+    _globals["_HAT"]._serialized_start = 43
+    _globals["_HAT"]._serialized_end = 105
+    _globals["_SIZE"]._serialized_start = 107
+    _globals["_SIZE"]._serialized_end = 129
+    _globals["_HABERDASHER"]._serialized_start = 131
+    _globals["_HABERDASHER"]._serialized_end = 210
 # @@protoc_insertion_point(module_scope)

--- a/example/haberdasher_pb2.pyi
+++ b/example/haberdasher_pb2.pyi
@@ -12,7 +12,12 @@ class Hat(_message.Message):
     size: int
     color: str
     name: str
-    def __init__(self, size: _Optional[int] = ..., color: _Optional[str] = ..., name: _Optional[str] = ...) -> None: ...
+    def __init__(
+        self,
+        size: _Optional[int] = ...,
+        color: _Optional[str] = ...,
+        name: _Optional[str] = ...,
+    ) -> None: ...
 
 class Size(_message.Message):
     __slots__ = ("inches",)

--- a/protoc-gen-connecpy/generator/generator.go
+++ b/protoc-gen-connecpy/generator/generator.go
@@ -3,7 +3,6 @@ package generator
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"path"
 	"strings"
 
@@ -41,21 +40,21 @@ func GenerateConnecpyFile(fd *descriptor.FileDescriptorProto) (*plugin.CodeGener
 	moduleName := strings.Join(strings.Split(fileNameWithoutSuffix, "/"), ".")
 
 	vars := ConnecpyTemplateVariables{
-		FileName:              name,
-		ModuleName:            moduleName,
+		FileName:   name,
+		ModuleName: moduleName,
 	}
 
 	svcs := fd.GetService()
+	packageName := fd.GetPackage()
 	for _, svc := range svcs {
-		svcURL := fmt.Sprintf("%s.%s", fd.GetPackage(), svc.GetName())
 		connecpySvc := &ConnecpyService{
-			Name:       svc.GetName(),
-			ServiceURL: svcURL,
+			Name:    svc.GetName(),
+			Package: packageName,
 		}
 
 		for _, method := range svc.GetMethod() {
 			connecpyMethod := &ConnecpyMethod{
-				ServiceURL:  svcURL,
+				Package:     packageName,
 				ServiceName: connecpySvc.Name,
 				Name:        method.GetName(),
 				InputType:   getSymbolName(method.GetInputType()),

--- a/src/connecpy/server.py
+++ b/src/connecpy/server.py
@@ -7,8 +7,7 @@ class ConnecpyServer:
     Represents a Connecpy server that handles incoming requests and dispatches them to the appropriate endpoints.
     """
 
-    def __init__(self, *, service):
-        self.service = service
+    def __init__(self):
         self._endpoints = {}
         self._prefix = ""
 


### PR DESCRIPTION
## WHAT
This PR adds `serviceName` method to a generated server class.
For example, it returns `foo.v1.BarServcie` for `BarServer` class of `foo.v1` package .

## WHY
Currently, users of a generated server class don't have the way to get the service name.