### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "connecpy"
-version = "1.0.7"
+version = "1.1.0"
 description = "Code generator, server library and client library for the Connect Protocol"
 authors = [
     { name = "Yasushi Itoh" }


### PR DESCRIPTION
## WHAT
SSIA

## WHY
I changed the version number to 1.0.7 just before, but that was a mistake 😓 
We introduced a new feature, so it needs to be a minor version change, not a patch version. Therefore, I will change the version number to 1.1.0 (same content as 1.0.7).