### PR TITLE
fix(wsgi): an uninitialized local variable `compressor`

### DIFF
--- a/src/connecpy/wsgi.py
+++ b/src/connecpy/wsgi.py
@@ -426,6 +426,7 @@ class ConnecpyWSGIApp(base.ConnecpyBaseApp):
             accept_encoding = request_headers.get("accept-encoding", "identity")
             selected_encoding = compression.select_encoding(accept_encoding)
             compressed_bytes = None
+            compressor = None
             if selected_encoding != "identity":
                 compressor = compression.get_compressor(selected_encoding)
                 if compressor:


### PR DESCRIPTION
This pull request includes a small change to the `src/connecpy/wsgi.py` file. The change initializes the `compressor` variable to `None` before it is potentially assigned a value within a conditional block. This ensures that the variable is defined even if the condition is not met.

Changes in `src/connecpy/wsgi.py`:

* Initialized the `compressor` variable to `None` before the conditional block to ensure it is defined.