### PR TITLE
chore: release 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "connecpy"
-version = "1.4.0"
+version = "1.4.1"
 description = "Code generator, server library and client library for the Connect Protocol"
 authors = [
     { name = "Yasushi Itoh" }

--- a/uv.lock
+++ b/uv.lock
@@ -264,7 +264,7 @@ wheels = [
 
 [[package]]
 name = "connecpy"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the version number of the `connecpy` project from `1.4.0` to `1.4.1`.