### PR TITLE
fix: handle errors following connect protocol

### DIFF
--- a/src/connecpy/_protocol.py
+++ b/src/connecpy/_protocol.py
@@ -1,0 +1,106 @@
+from dataclasses import asdict, dataclass
+from http import HTTPStatus
+import json
+
+from .errors import Errors
+from .exceptions import ConnecpyServerException
+
+
+# Define a custom class for HTTP Status to allow adding 499 status code
+@dataclass(frozen=True)
+class ExtendedHTTPStatus:
+    code: int
+    reason: str
+
+    @staticmethod
+    def from_http_status(status: HTTPStatus) -> "ExtendedHTTPStatus":
+        return ExtendedHTTPStatus(code=status.value, reason=status.phrase)
+
+
+# Dedupe statuses that are mapped multiple times
+_BAD_REQUEST = ExtendedHTTPStatus.from_http_status(HTTPStatus.BAD_REQUEST)
+_CONFLICT = ExtendedHTTPStatus.from_http_status(HTTPStatus.CONFLICT)
+_INTERNAL_SERVER_ERROR = ExtendedHTTPStatus.from_http_status(
+    HTTPStatus.INTERNAL_SERVER_ERROR
+)
+
+_error_to_http_status = {
+    Errors.Canceled: ExtendedHTTPStatus(499, "Client Closed Request"),
+    Errors.Unknown: _INTERNAL_SERVER_ERROR,
+    Errors.InvalidArgument: _BAD_REQUEST,
+    Errors.DeadlineExceeded: ExtendedHTTPStatus.from_http_status(
+        HTTPStatus.GATEWAY_TIMEOUT
+    ),
+    Errors.NotFound: ExtendedHTTPStatus.from_http_status(HTTPStatus.NOT_FOUND),
+    Errors.AlreadyExists: _CONFLICT,
+    Errors.PermissionDenied: ExtendedHTTPStatus.from_http_status(HTTPStatus.FORBIDDEN),
+    Errors.ResourceExhausted: ExtendedHTTPStatus.from_http_status(
+        HTTPStatus.TOO_MANY_REQUESTS
+    ),
+    Errors.FailedPrecondition: _BAD_REQUEST,
+    Errors.Aborted: _CONFLICT,
+    Errors.OutOfRange: _BAD_REQUEST,
+    Errors.Unimplemented: ExtendedHTTPStatus.from_http_status(
+        HTTPStatus.NOT_IMPLEMENTED
+    ),
+    Errors.Internal: _INTERNAL_SERVER_ERROR,
+    Errors.Unavailable: ExtendedHTTPStatus.from_http_status(
+        HTTPStatus.SERVICE_UNAVAILABLE
+    ),
+    Errors.DataLoss: _INTERNAL_SERVER_ERROR,
+    Errors.Unauthenticated: ExtendedHTTPStatus.from_http_status(
+        HTTPStatus.UNAUTHORIZED
+    ),
+    # Custom error codes not defined by Connec
+    Errors.NoError: ExtendedHTTPStatus.from_http_status(HTTPStatus.OK),
+    Errors.BadRoute: ExtendedHTTPStatus.from_http_status(HTTPStatus.NOT_FOUND),
+    Errors.Malformed: _BAD_REQUEST,
+}
+
+
+_http_status_code_to_error = {
+    400: Errors.Internal,
+    401: Errors.Unauthenticated,
+    403: Errors.PermissionDenied,
+    404: Errors.Unimplemented,
+    429: Errors.Unavailable,
+    502: Errors.Unavailable,
+    503: Errors.Unavailable,
+    504: Errors.Unavailable,
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ConnectWireError:
+    code: Errors
+    message: str
+
+    @staticmethod
+    def from_exception(exc: Exception) -> "ConnectWireError":
+        if isinstance(exc, ConnecpyServerException):
+            return ConnectWireError(code=exc.code, message=exc.message)
+        return ConnectWireError(code=Errors.Unknown, message=str(exc))
+
+    @staticmethod
+    def from_dict(data: dict, http_status_code: int) -> "ConnectWireError":
+        code_str = data.get("code")
+        if code_str:
+            try:
+                code = Errors(code_str)
+            except ValueError:
+                code = _http_status_code_to_error.get(http_status_code, Errors.Unknown)
+        else:
+            code = _http_status_code_to_error.get(http_status_code, Errors.Unknown)
+        message = data.get("message", "")
+        return ConnectWireError(code=code, message=message)
+
+    def to_exception(self) -> ConnecpyServerException:
+        return ConnecpyServerException(code=self.code, message=self.message)
+
+    def to_http_status(self) -> ExtendedHTTPStatus:
+        return _error_to_http_status.get(self.code, _INTERNAL_SERVER_ERROR)
+
+    def to_json_bytes(self) -> bytes:
+        return json.dumps({"code": self.code.value, "message": self.message}).encode(
+            "utf-8"
+        )

--- a/src/connecpy/_protocol.py
+++ b/src/connecpy/_protocol.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from http import HTTPStatus
 import json
 

--- a/src/connecpy/async_client.py
+++ b/src/connecpy/async_client.py
@@ -108,9 +108,7 @@ class AsyncConnecpyClient:
                     )
                 return response
             else:
-                raise ConnectWireError.from_dict(
-                    resp.json(), resp.status_code
-                ).to_exception()
+                raise ConnectWireError.from_response(resp).to_exception()
         except httpx.TimeoutException as e:
             raise exceptions.ConnecpyServerException(
                 code=errors.Errors.DeadlineExceeded,

--- a/src/connecpy/async_client.py
+++ b/src/connecpy/async_client.py
@@ -7,6 +7,7 @@ from . import compression
 from . import context
 from . import exceptions
 from . import errors
+from ._protocol import ConnectWireError
 
 
 class AsyncConnecpyClient:
@@ -97,26 +98,28 @@ class AsyncConnecpyClient:
                     url=self._address + url, content=request_data, **kwargs
                 )
 
-            resp.raise_for_status()
-
             if resp.status_code == 200:
                 response = response_class()
-                response.ParseFromString(resp.content)
+                try:
+                    response.ParseFromString(resp.content)
+                except Exception as e:
+                    raise exceptions.ConnecpyException(
+                        f"Failed to parse response message: {str(e)}"
+                    )
                 return response
             else:
-                raise exceptions.ConnecpyServerException.from_json(await resp.json())
+                raise ConnectWireError.from_dict(
+                    resp.json(), resp.status_code
+                ).to_exception()
         except httpx.TimeoutException as e:
             raise exceptions.ConnecpyServerException(
                 code=errors.Errors.DeadlineExceeded,
                 message=str(e) or "request timeout",
             )
-        except httpx.HTTPStatusError as e:
-            raise exceptions.ConnecpyServerException(
-                code=errors.Errors.Unavailable,
-                message=str(e),
-            )
+        except exceptions.ConnecpyException:
+            raise
         except Exception as e:
             raise exceptions.ConnecpyServerException(
-                code=errors.Errors.Internal,
+                code=errors.Errors.Unavailable,
                 message=str(e),
             )

--- a/src/connecpy/client.py
+++ b/src/connecpy/client.py
@@ -87,10 +87,7 @@ class ConnecpyClient:
                     )
                 return response
             else:
-                raise ConnectWireError.from_dict(
-                    resp.json(), resp.status_code
-                ).to_exception()
-
+                raise ConnectWireError.from_response(resp).to_exception()
         except httpx.TimeoutException as e:
             raise exceptions.ConnecpyServerException(
                 code=errors.Errors.DeadlineExceeded,

--- a/src/connecpy/errors.py
+++ b/src/connecpy/errors.py
@@ -11,10 +11,8 @@ class Errors(Enum):
     InvalidArgument = "invalid_argument"
     DeadlineExceeded = "deadline_exceeded"
     NotFound = "not_found"
-    BadRoute = "bad_route"
     AlreadyExists = "already_exists"
     PermissionDenied = "permission_denied"
-    Unauthenticated = "unauthenticated"
     ResourceExhausted = "resource_exhausted"
     FailedPrecondition = "failed_precondition"
     Aborted = "aborted"
@@ -23,8 +21,12 @@ class Errors(Enum):
     Internal = "internal"
     Unavailable = "unavailable"
     DataLoss = "data_loss"
-    Malformed = "malformed"
+    Unauthenticated = "unauthenticated"
+
+    # Custom error codes not defined by Connect
     NoError = ""
+    BadRoute = "bad_route"
+    Malformed = "malformed"
 
     @staticmethod
     def get_status_code(code: "Errors") -> int:

--- a/src/connecpy/errors.py
+++ b/src/connecpy/errors.py
@@ -29,6 +29,22 @@ class Errors(Enum):
     Malformed = "malformed"
 
     @staticmethod
+    def from_string(code: str) -> "Errors":
+        """
+        Converts a string code to an Errors enum member.
+
+        Args:
+            code (str): The error code as a string.
+
+        Returns:
+            Errors: The corresponding Errors enum member.
+        """
+        try:
+            return Errors(code)
+        except ValueError:
+            return Errors.Unknown
+
+    @staticmethod
     def get_status_code(code: "Errors") -> int:
         """
         Returns the corresponding HTTP status code for the given error code.

--- a/src/connecpy/exceptions.py
+++ b/src/connecpy/exceptions.py
@@ -10,7 +10,7 @@ class ConnecpyException(Exception):
     pass
 
 
-class ConnecpyServerException(httplib.HTTPException):
+class ConnecpyServerException(ConnecpyException):
     """
     Exception class for Connecpy server errors.
 

--- a/src/connecpy/exceptions.py
+++ b/src/connecpy/exceptions.py
@@ -1,4 +1,3 @@
-import http.client as httplib
 import json
 
 from . import errors

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -1,0 +1,141 @@
+from httpx import (
+    ASGITransport,
+    AsyncClient,
+    Client,
+    Response,
+    WSGITransport,
+)
+import pytest
+from connecpy.asgi import ConnecpyASGIApp
+from connecpy.errors import Errors
+from connecpy.exceptions import ConnecpyServerException
+from connecpy.wsgi import ConnecpyWSGIApp
+from example.haberdasher_connecpy import (
+    AsyncHaberdasherClient,
+    Haberdasher,
+    HaberdasherServer,
+    HaberdasherSync,
+    HaberdasherServerSync,
+    HaberdasherClient,
+)
+from example.haberdasher_pb2 import Size
+from google.protobuf.empty_pb2 import Empty
+
+
+_errors = [
+    (Errors.Canceled, "Operation was cancelled", 499),
+    (Errors.Unknown, "An unknown error occurred", 500),
+    (Errors.InvalidArgument, "That's not right", 400),
+    (Errors.DeadlineExceeded, "Deadline exceeded", 504),
+    (Errors.NotFound, "Resource not found", 404),
+    (Errors.AlreadyExists, "Resource already exists", 409),
+    (Errors.PermissionDenied, "Permission denied", 403),
+    (Errors.ResourceExhausted, "Resource exhausted", 429),
+    (Errors.FailedPrecondition, "Failed precondition", 400),
+    (Errors.Aborted, "Operation aborted", 409),
+    (Errors.OutOfRange, "Out of range", 400),
+    (Errors.Unimplemented, "Method not implemented", 501),
+    (Errors.Internal, "Internal server error", 500),
+    (Errors.Unavailable, "Service unavailable", 503),
+    (Errors.DataLoss, "Data loss occurred", 500),
+    (Errors.Unauthenticated, "Unauthenticated access", 401),
+    # Custom error codes not defined by Connect
+    (Errors.BadRoute, "Bad route", 404),
+    (Errors.Malformed, "Malformed request", 400),
+]
+
+
+class ErrorHaberdasherSync(HaberdasherSync):
+    def __init__(self, exception: ConnecpyServerException):
+        self._exception = exception
+
+    def MakeHat(self, _req, _ctx):
+        raise self._exception
+
+    def DoNothing(self, _req, _ctx):
+        return Empty()
+
+
+@pytest.mark.parametrize("error,message,http_status", _errors)
+def test_sync_errors(
+    error: Errors,
+    message: str,
+    http_status: int,
+):
+    haberdasher = ErrorHaberdasherSync(
+        ConnecpyServerException(
+            code=error,
+            message=message,
+        )
+    )
+    server = HaberdasherServerSync(service=haberdasher)
+    app = ConnecpyWSGIApp()
+    app.add_service(server)
+    transport = WSGITransport(app)
+
+    recorded_response: Response = None
+
+    def record_response(response):
+        nonlocal recorded_response
+        recorded_response = response
+
+    session = Client(transport=transport, event_hooks={"response": [record_response]})
+
+    with (
+        HaberdasherClient("http://localhost", session=session) as client,
+        pytest.raises(ConnecpyServerException) as exc_info,
+    ):
+        client.MakeHat(request=Size(inches=10))
+
+    assert exc_info.value.code == error
+    assert exc_info.value.message == message
+    assert recorded_response.status_code == http_status
+
+
+class ErrorHaberdasher(Haberdasher):
+    def __init__(self, exception: ConnecpyServerException):
+        self._exception = exception
+
+    async def MakeHat(self, _req, _ctx):
+        raise self._exception
+
+    async def DoNothing(self, _req, _ctx):
+        return Empty()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error,message,http_status", _errors)
+async def test_async_errors(
+    error: Errors,
+    message: str,
+    http_status: int,
+):
+    haberdasher = ErrorHaberdasher(
+        ConnecpyServerException(
+            code=error,
+            message=message,
+        )
+    )
+    server = HaberdasherServer(service=haberdasher)
+    app = ConnecpyASGIApp()
+    app.add_service(server)
+    transport = ASGITransport(app)
+
+    recorded_response: Response = None
+
+    async def record_response(response):
+        nonlocal recorded_response
+        recorded_response = response
+
+    async with (
+        AsyncClient(
+            transport=transport, event_hooks={"response": [record_response]}
+        ) as session,
+        AsyncHaberdasherClient("http://localhost", session=session) as client,
+    ):
+        with pytest.raises(ConnecpyServerException) as exc_info:
+            await client.MakeHat(request=Size(inches=10))
+
+    assert exc_info.value.code == error
+    assert exc_info.value.message == message
+    assert recorded_response.status_code == http_status


### PR DESCRIPTION
I noticed error handling is not consistent with connect protocol - being an implementation of it, I think it's necessary to follow it exactly. I have reverse engineered the handling from connect-go, putting it in an implementation detail module `_protocol` to encapsulate it as best as possible.

The most important references are the mapping between connect code and HTTP

https://github.com/connectrpc/connect-go/blob/main/protocol_connect.go#L1269
https://github.com/connectrpc/connect-go/blob/main/protocol.go#L401

Some are different from the current mapping in

https://github.com/i2y/connecpy/blob/main/src/connecpy/errors.py#L41

but I feel it must be fixed for compatibility. Let me know if you rely on the old mapping and I can try to provide some compatibility layer, hopefully temporarily. 