### PR TITLE
fix: remove non-spec error codes

### DIFF
--- a/src/connecpy/_protocol.py
+++ b/src/connecpy/_protocol.py
@@ -53,10 +53,6 @@ _error_to_http_status = {
     Errors.Unauthenticated: ExtendedHTTPStatus.from_http_status(
         HTTPStatus.UNAUTHORIZED
     ),
-    # Custom error codes not defined by Connect
-    Errors.NoError: ExtendedHTTPStatus.from_http_status(HTTPStatus.OK),
-    Errors.BadRoute: ExtendedHTTPStatus.from_http_status(HTTPStatus.NOT_FOUND),
-    Errors.Malformed: _BAD_REQUEST,
 }
 
 
@@ -120,3 +116,11 @@ class ConnectWireError:
         return json.dumps({"code": self.code.value, "message": self.message}).encode(
             "utf-8"
         )
+
+
+class HTTPException(Exception):
+    """An HTTP exception returned directly before starting the connect protocol."""
+
+    def __init__(self, status: HTTPStatus, headers: list[tuple[str, str]]):
+        self.status = status
+        self.headers = headers

--- a/src/connecpy/encoding.py
+++ b/src/connecpy/encoding.py
@@ -82,6 +82,15 @@ def get_decoder_by_name(encoding_name: str) -> Optional[Decoder]:
     return decoders.get(encoding_name)
 
 
+def get_decoder_by_content_type(ctype: str) -> Optional[Decoder]:
+    """Get decoder function by content type."""
+    decoders = {
+        "application/json": json_decoder,
+        "application/proto": proto_decoder,
+    }
+    return decoders.get(ctype)
+
+
 def get_encoder(
     endpoint: Any, ctype: str
 ) -> Callable[[Any], Tuple[bytes, Dict[str, List[str]]]]:
@@ -91,8 +100,10 @@ def get_encoder(
     elif ctype == "application/proto":
         return partial(proto_encoder, data_obj=endpoint.output)
     else:
+        # Currently not possible because we validate content type before
+        # getting encoder.
         raise exceptions.ConnecpyServerException(
-            code=errors.Errors.BadRoute,
+            code=errors.Errors.Internal,
             message=f"unexpected Content-Type: {ctype}",
         )
 

--- a/src/connecpy/errors.py
+++ b/src/connecpy/errors.py
@@ -23,11 +23,6 @@ class Errors(Enum):
     DataLoss = "data_loss"
     Unauthenticated = "unauthenticated"
 
-    # Custom error codes not defined by Connect
-    NoError = ""
-    BadRoute = "bad_route"
-    Malformed = "malformed"
-
     @staticmethod
     def from_string(code: str) -> "Errors":
         """
@@ -59,10 +54,8 @@ class Errors(Enum):
             Errors.Canceled: 408,
             Errors.Unknown: 500,
             Errors.InvalidArgument: 400,
-            Errors.Malformed: 400,
             Errors.DeadlineExceeded: 408,
             Errors.NotFound: 404,
-            Errors.BadRoute: 404,
             Errors.AlreadyExists: 409,
             Errors.PermissionDenied: 403,
             Errors.Unauthenticated: 401,
@@ -74,5 +67,4 @@ class Errors(Enum):
             Errors.Internal: 500,
             Errors.Unavailable: 503,
             Errors.DataLoss: 500,
-            Errors.NoError: 200,
         }.get(code, 500)

--- a/src/connecpy/exceptions.py
+++ b/src/connecpy/exceptions.py
@@ -80,7 +80,6 @@ def connecpy_error_from_intermediary(status, reason, headers, body):
             400: errors.Errors.Internal,  # JSON response should have been returned
             401: errors.Errors.Unauthenticated,
             403: errors.Errors.PermissionDenied,
-            404: errors.Errors.BadRoute,
             429: errors.Errors.ResourceExhausted,
             502: errors.Errors.Unavailable,
             503: errors.Errors.Unavailable,

--- a/src/connecpy/server.py
+++ b/src/connecpy/server.py
@@ -1,7 +1,3 @@
-from . import exceptions
-from . import errors
-
-
 class ConnecpyServer:
     """
     Represents a Connecpy server that handles incoming requests and dispatches them to the appropriate endpoints.
@@ -17,33 +13,3 @@ class ConnecpyServer:
         Represents the prefix used for routing requests to endpoints.
         """
         return self._prefix
-
-    def get_endpoint(self, path):
-        """
-        Get the endpoint associated with the given path.
-
-        Args:
-            path (str): The path of the request.
-
-        Returns:
-            object: The endpoint associated with the given path.
-
-        Raises:
-            ConnecpyServerException: If no handler is found for the path or if the service has no endpoint for the given method.
-        """
-        (_, url_pre, rpc_method) = path.rpartition(f"{self._prefix}/")
-
-        if not url_pre or not rpc_method:
-            raise exceptions.ConnecpyServerException(
-                code=errors.Errors.BadRoute,
-                message=f"no handler for path {path}",
-            )
-
-        endpoint = self._endpoints.get(rpc_method, None)
-        if not endpoint:
-            raise exceptions.ConnecpyServerException(
-                code=errors.Errors.Unimplemented,
-                message=f"service has no endpoint {rpc_method}",
-            )
-
-        return endpoint


### PR DESCRIPTION
I have followed connect-go handler code to better reproduce its error handling outside connect protocol

https://github.com/connectrpc/connect-go/blob/main/handler.go#L174

In addition, non-matched paths are handled as straight 404 in generated code, not in framework for it, so I reproduced that too. Now, there aren't any out-of-spec error codes