### PR TITLE
fix: rework client timeouts to work closer to connect

### DIFF
--- a/example/client.py
+++ b/example/client.py
@@ -6,7 +6,7 @@ import haberdasher_pb2
 
 
 server_url = "http://localhost:3000"
-timeout_s = 5
+timeout_ms = 5000
 
 
 def create_large_request():
@@ -19,7 +19,7 @@ def create_large_request():
 
 def main():
     with haberdasher_connecpy.HaberdasherClient(
-        server_url, timeout=timeout_s
+        server_url, timeout_ms=timeout_ms
     ) as client:
         # Example 1: POST request with gzip compression (large request)
         try:

--- a/src/connecpy/async_client.py
+++ b/src/connecpy/async_client.py
@@ -22,7 +22,9 @@ class AsyncConnecpyClient:
 
     Args:
         address (str): The address of the Connecpy server.
-        session (httpx.AsyncClient): The httpx client session to use for making requests.
+        timeout_ms (int): The timeout in ms for the overall request.
+        session (httpx.AsyncClient): The httpx client session to use for making requests. If setting timeout_ms,
+            the session should have timeout disabled or set higher than timeout_ms.
     """
 
     def __init__(

--- a/src/connecpy/client.py
+++ b/src/connecpy/client.py
@@ -3,6 +3,7 @@ from typing import Optional, TypeVar
 import httpx
 
 from google.protobuf.message import Message
+from httpx import Timeout
 
 from . import context
 from . import exceptions
@@ -21,17 +22,25 @@ class ConnecpyClient:
 
     Args:
         address (str): The address of the Connecpy server.
-        session (httpx.Client): The httpx client session to use for making requests.
+        timeout_ms (int): The timeout in ms for the overall request. Note, this is currently only implemented
+            as a read timeout, which will be more forgiving than a timeout for the operation.
+        session (httpx.Client): The httpx client session to use for making requests. If setting timeout_ms,
+            the session should also at least have a read timeout set to the same value.
     """
 
-    def __init__(self, address: str, timeout=5, session: Optional[httpx.Client] = None):
+    def __init__(
+        self,
+        address: str,
+        timeout_ms: Optional[int] = None,
+        session: Optional[httpx.Client] = None,
+    ):
         self._address = address
-        self._timeout = timeout
+        self._timeout_ms = timeout_ms
         if session:
             self._session = session
             self._close_client = False
         else:
-            self._session = httpx.Client()
+            self._session = httpx.Client(timeout=_convert_connect_timeout(timeout_ms))
             self._close_client = True
         self._closed = False
 
@@ -56,11 +65,17 @@ class ConnecpyClient:
         ctx: Optional[context.ClientContext],
         response_class: type[_RES],
         method="POST",
+        timeout_ms: Optional[int] = None,
         **kwargs,
     ) -> _RES:
         """Make an HTTP request to the server."""
         # Prepare headers and kwargs using shared logic
-        headers, kwargs = shared_client.prepare_headers(ctx, kwargs, self._timeout)
+        if timeout_ms is None:
+            timeout_ms = self._timeout_ms
+        else:
+            timeout = _convert_connect_timeout(timeout_ms)
+            kwargs["timeout"] = timeout
+        headers, kwargs = shared_client.prepare_headers(ctx, kwargs, timeout_ms)
 
         try:
             if "content-encoding" in headers:
@@ -91,10 +106,10 @@ class ConnecpyClient:
                 return response
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
-        except httpx.TimeoutException as e:
+        except httpx.TimeoutException:
             raise exceptions.ConnecpyServerException(
                 code=errors.Errors.DeadlineExceeded,
-                message=str(e) or "request timeout",
+                message="Request timed out",
             )
         except exceptions.ConnecpyException:
             raise
@@ -102,3 +117,14 @@ class ConnecpyClient:
             raise exceptions.ConnecpyServerException(
                 code=errors.Errors.Unavailable, message=str(e)
             )
+
+
+# Convert a timeout with connect semantics to a httpx.Timeout. Connect timeouts
+# should apply to an entire operation but this is difficult in synchronous Python code
+# to do cross-platform. For now, we just apply the timeout to all httpx timeouts
+# if provided, or default to no read/write timeouts but with a connect timeout if
+# not provided to match connect-go behavior as closely as possible.
+def _convert_connect_timeout(timeout_ms: Optional[int]) -> Timeout:
+    if timeout_ms is None:
+        return Timeout(None, connect=30.0)
+    return Timeout(timeout_ms / 1000.0)

--- a/src/connecpy/shared_client.py
+++ b/src/connecpy/shared_client.py
@@ -4,7 +4,9 @@ from typing import Optional
 from . import context
 
 
-def prepare_headers(ctx: Optional[context.ClientContext], kwargs, timeout):
+def prepare_headers(
+    ctx: Optional[context.ClientContext], kwargs, timeout_ms: Optional[int]
+):
     # Lowercase all keys to ensure consistent header casing
     headers = {k.lower(): v for k, v in ctx.get_headers().items()} if ctx else {}
     if "headers" in kwargs:
@@ -20,9 +22,8 @@ def prepare_headers(ctx: Optional[context.ClientContext], kwargs, timeout):
         headers["content-type"] = "application/proto"
     if "accept-encoding" not in headers:
         headers["accept-encoding"] = "gzip, br, zstd"
-    if "timeout" not in kwargs:
-        kwargs["timeout"] = timeout
-        headers["connect-timeout-ms"] = str(timeout * 1000)
+    if timeout_ms is not None:
+        headers["connect-timeout-ms"] = str(timeout_ms)
     kwargs["headers"] = headers
     return headers, kwargs
 


### PR DESCRIPTION
I noticed that timeouts work differently here versus other connect implementations, or gRPC notably that a default timeout of 5s is applied and it can't be set to `None`. I understand the desire to have timeouts by default, but I think it's more important to match the behavior of connectrpc so things are consistent when using it across multiple languages in a system.

The main changes of this PR are

- Make timeout an integer of milliseconds, which is what connect's timeout is. This also matches connect-es
- Make the default no read timeout to match others. Connect does not well define its socket connect timeout so I followed the pattern of connect-go, which effectively is using Go's default of 30s connect timeout, no other timeouts
- Apply the timeout to the entire operation for async where it is simple to do so