### PR TITLE
perf: optimize WSGI read_chunked() to match ASGI's efficient implementation

### DIFF
--- a/src/connecpy/wsgi.py
+++ b/src/connecpy/wsgi.py
@@ -156,7 +156,7 @@ def prepare_response_headers(
 
 
 def read_chunked(input_stream):
-    body = b""
+    chunks = []
     while True:
         line = input_stream.readline()
         if not line:
@@ -168,9 +168,9 @@ def read_chunked(input_stream):
             break
 
         chunk = input_stream.read(chunk_size)
-        body += chunk
+        chunks.append(chunk)
         input_stream.read(2)  # CRLF
-    return body
+    return b"".join(chunks)
 
 
 class ConnecpyWSGIApp(base.ConnecpyBaseApp):


### PR DESCRIPTION
## WHAT
- Optimize read_chunked() in WSGI to use list + join pattern instead of byte concatenation
- Matches the efficient implementation already used in ASGI

## WHY
- Byte concatenation (body += chunk) creates new objects on each iteration, resulting in O(n²) complexity
- List append + join is O(n) and more memory efficient for large chunked payloads
