### PR TITLE
chore: add type cast for Starlette ASGI compatibility

### DIFF
--- a/example/starlette_mount.py
+++ b/example/starlette_mount.py
@@ -1,9 +1,12 @@
+from typing import cast
+
 from server import app as server_app
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.routing import Mount, Route
+from starlette.types import ASGIApp
 
 app = Starlette(
     routes=[
@@ -13,7 +16,7 @@ app = Starlette(
         ),
         Mount(
             "/",
-            app=server_app,
+            app=cast(ASGIApp, server_app),
             name="haberdasher",
         ),
     ],


### PR DESCRIPTION
## WHAT
This PR adds type cast to resolve pyright error in starlette_mount.py on Ubuntu CI.

## WHY
- Starlette and asgiref use incompatible ASGI type definitions
- Cast is a no-op at runtime but satisfies the type checker
