### PR TITLE
feat: provide access to response headers/trailers for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ import asyncio
 
 import httpx
 
-from connecpy.context import ClientContext
 from connecpy.exceptions import ConnecpyServerException
 
 import haberdasher_connecpy, haberdasher_pb2
@@ -126,8 +125,7 @@ async def main():
 
     try:
         response = await client.MakeHat(
-            ctx=ClientContext(),
-            request=haberdasher_pb2.Size(inches=12),
+            haberdasher_pb2.Size(inches=12),
             # Optionally provide a session per request
             # session=session,
         )
@@ -157,7 +155,6 @@ name: "bowler"
 
 ```python
 # client.py
-from connecpy.context import ClientContext
 from connecpy.exceptions import ConnecpyServerException
 
 import haberdasher_connecpy, haberdasher_pb2
@@ -171,8 +168,7 @@ def main():
     with haberdasher_connecpy.HaberdasherClient(server_url, timeout=timeout_s) as client:
         try:
             response = client.MakeHat(
-                ctx=ClientContext(),
-                request=haberdasher_pb2.Size(inches=12),
+                haberdasher_pb2.Size(inches=12),
             )
             if not response.HasField("name"):
                 print("We didn't get a name!")
@@ -267,17 +263,12 @@ The compression handling is built into both ASGI and WSGI applications. You don'
 
 For synchronous clients:
 ```python
-from connecpy.context import ClientContext
 
 with HaberdasherClient(server_url) as client:
     response = client.MakeHat(
-        ctx=ClientContext(
-            headers={
-                "Content-Encoding": "br",  # Use Brotli compression for request
-                "Accept-Encoding": "gzip",  # Accept gzip compressed response
-            }
-        ),
-        request=request_obj,
+        request_obj,
+        send_compression="br",
+        accept_compression=("gzip,")
     )
 ```
 
@@ -285,24 +276,18 @@ For async clients:
 ```python
 async with AsyncHaberdasherClient(server_url) as client:
     response = await client.MakeHat(
-        ctx=ClientContext(),
-        request=request_obj,
-        headers={
-            "Content-Encoding": "zstd",  # Use Zstandard compression for request
-            "Accept-Encoding": "br",     # Accept Brotli compressed response
-        },
+        request_obj,
+        send_compression="zstd",  # Use Zstandard compression for request
+        accept_compression=("br,")  # Accept Brotli compressed response
     )
 ```
 
 Using GET requests with compression:
 ```python
 response = client.MakeHat(
-    ctx=ClientContext(),
     request=request_obj,
     use_get=True,  # Enable GET request (for methods marked with no_side_effects)
-    params={
-        "compression": "gzip",  # Use gzip compression for the message
-    }
+    send_compression="gzip",  # Use gzip compression for the message
 )
 ```
 
@@ -335,7 +320,6 @@ service = haberdasher_connecpy.HaberdasherServer(
 ```python
 # async_client.py
 response = await client.MakeHat(
-    ctx=ClientContext(),
     request=haberdasher_pb2.Size(inches=12),
     server_path_prefix="/foo/bar",
 )

--- a/src/connecpy/async_client.py
+++ b/src/connecpy/async_client.py
@@ -12,6 +12,7 @@ from . import errors
 from ._protocol import ConnectWireError
 from .types import Headers
 
+Response = shared_client.Response
 
 _RES = TypeVar("_RES", bound=Message)
 
@@ -73,25 +74,7 @@ class AsyncConnecpyClient:
         timeout_ms: Optional[int] = None,
         session: Optional[httpx.AsyncClient] = None,
     ) -> _RES:
-        """
-        Makes a request to the Connecpy server.
-
-        Args:
-            url (str): The URL to send the request to.
-            request: The request object to send.
-            ctx (context.ClientContext): The client context.
-            response_obj: The response object class to deserialize the response into.
-            method (str): The HTTP method to use for the request. Defaults to "POST".
-            session (httpx.AsyncClient, optional): The httpx client session to use for the request.
-                If not provided, the session passed to the constructor will be used.
-            **kwargs: Additional keyword arguments to pass to the request.
-
-        Returns:
-            The deserialized response object.
-
-        Raises:
-            exceptions.ConnecpyServerException: If an error occurs while making the request.
-        """
+        """Make an HTTP request to the server."""
         # Prepare headers and request args using shared logic
         request_args = {}
         if timeout_ms is None:
@@ -138,6 +121,8 @@ class AsyncConnecpyClient:
                     ),
                     timeout_s,
                 )
+
+            shared_client.handle_response_headers(resp.headers)
 
             if resp.status_code == 200:
                 response = response_class()

--- a/src/connecpy/base.py
+++ b/src/connecpy/base.py
@@ -110,7 +110,7 @@ class Endpoint(Generic[T, U]):
 
 
 def thread_pool_runner(func):
-    async def run(request, ctx: context.ConnecpyServiceContext):
+    async def run(request, ctx: context.ServiceContext):
         return await asyncio.to_thread(func, request, ctx)
 
     return run

--- a/src/connecpy/client.py
+++ b/src/connecpy/client.py
@@ -13,6 +13,9 @@ from ._protocol import ConnectWireError
 from .types import Headers
 
 
+Response = shared_client.Response
+
+
 _RES = TypeVar("_RES", bound=Message)
 
 
@@ -109,6 +112,8 @@ class ConnecpyClient:
                     headers=request_headers,
                     **request_args,
                 )
+
+            shared_client.handle_response_headers(resp.headers)
 
             if resp.status_code == 200:
                 response = response_class()

--- a/src/connecpy/context.py
+++ b/src/connecpy/context.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Protocol, Mapping, MutableMapping, List, Union
+from typing import Mapping, Iterable, List, Optional, Union
 import time
 
 from . import errors
@@ -7,176 +7,7 @@ from . import exceptions
 from ._protocol import HTTPException
 
 
-class ClientContext:
-    """Context object for storing context information of
-    request currently being processed.
-
-    Attributes:
-        _values (Dict[str, Any]): Dictionary to store context key-value pairs.
-        _headers (MutableMapping[str, str]): Request headers.
-        _response_headers (MutableMapping[str, str]): Response headers.
-    """
-
-    def __init__(self, *, headers: Union[MutableMapping[str, str], None] = None):
-        """Create a new Context object
-
-        Keyword arguments:
-        headers (MutableMapping[str, str] | None): Headers for the request.
-        """
-
-        self._values = {}
-        if headers is None:
-            headers = {}
-        self._headers = headers
-        self._response_headers: MutableMapping[str, str] = {}
-
-    def set(self, key: str, value: Any) -> None:
-        """Set a Context value
-
-        Args:
-            key (str): Key for the context key-value pair.
-            value (Any): Value to be stored.
-        """
-
-        self._values[key] = value
-
-    def get(self, key: str) -> Any:
-        """Get a Context value
-
-        Args:
-            key (str): Key for the context key-value pair.
-
-        Returns:
-            Any: The value associated with the key.
-        """
-
-        return self._values[key]
-
-    def get_headers(self) -> MutableMapping[str, str]:
-        """Get request headers that are currently stored.
-
-        Returns:
-            MutableMapping[str, str]: The request headers.
-        """
-
-        return self._headers
-
-    def set_header(self, key: str, value: str) -> None:
-        """Set a request header
-
-        Args:
-            key (str): Key for the header.
-            value (str): Value for the header.
-        """
-
-        self._headers[key] = value
-
-    def get_response_headers(self) -> MutableMapping[str, str]:
-        """Get response headers that are currently stored.
-
-        Returns:
-            MutableMapping[str, str]: The response headers.
-        """
-
-        return self._response_headers
-
-    def set_response_header(self, key: str, value: str) -> None:
-        """Set a response header
-
-        Args:
-            key (str): Key for the header.
-            value (str): Value for the header.
-        """
-
-        self._response_headers[key] = value
-
-
-class ServiceContext(Protocol):
-    """Represents the context of a service."""
-
-    async def abort(self, code, message):
-        """Abort the service with the given code and message.
-
-        Args:
-            code (int): The error code.
-            message (str): The error message.
-        """
-        ...
-
-    def code(self) -> int:
-        """Get the error code.
-
-        Returns:
-            int: The error code.
-        """
-        ...
-
-    def details(self) -> str:
-        """Get the error details.
-
-        Returns:
-            str: The error details.
-        """
-        ...
-
-    def invocation_metadata(self) -> Mapping[str, List[str]]:
-        """Get the invocation metadata.
-
-        Returns:
-            Mapping[str, List[str]]: The invocation metadata.
-        """
-        ...
-
-    def peer(self) -> str:
-        """Get the peer information.
-
-        Returns:
-            str: The peer information.
-        """
-        ...
-
-    def set_code(self, code: int) -> None:
-        """Set the error code.
-
-        Args:
-            code (int): The error code.
-        """
-        ...
-
-    def set_details(self, details: str) -> None:
-        """Set the error details.
-
-        Args:
-            details (str): The error details.
-        """
-        ...
-
-    def set_trailing_metadata(self, metadata: Mapping[str, List[str]]) -> None:
-        """Set the trailing metadata.
-
-        Args:
-            metadata (Mapping[str, List[str]]): The trailing metadata.
-        """
-        ...
-
-    def time_remaining(self) -> Union[float, None]:
-        """Get the remaining time.
-
-        Returns:
-            float | None: The remaining time in seconds, or None if not applicable.
-        """
-        ...
-
-    def trailing_metadata(self) -> Mapping[str, List[str]]:
-        """Get the trailing metadata.
-
-        Returns:
-            Mapping[str, List[str]]: The trailing metadata.
-        """
-        ...
-
-
-class ConnecpyServiceContext:
+class ServiceContext:
     """
     Represents the context of a Connecpy service.
 
@@ -189,6 +20,9 @@ class ConnecpyServiceContext:
         _timeout_sec: The timeout duration in seconds.
         _start_time: The start time of the service.
     """
+
+    _response_headers: Optional[list[tuple[str, str]]] = None
+    _response_trailers: Optional[list[tuple[str, str]]] = None
 
     def __init__(self, peer: str, invocation_metadata: Mapping[str, List[str]]):
         """
@@ -311,17 +145,51 @@ class ConnecpyServiceContext:
         """
         self._details = details
 
-    def set_trailing_metadata(self, metadata: Mapping[str, List[str]]) -> None:
+    def response_headers(self) -> Iterable[tuple[str, str]]:
         """
-        Sets the trailing metadata for the context.
+        Returns the response headers that will be sent before the response.
+        """
+        if self._response_headers is None:
+            return ()
+        return self._response_headers
+
+    def add_response_header(self, key: str, value: str) -> None:
+        """
+        Add a response header to send before the response.
 
         Args:
-            metadata (Mapping[str, List[str]]): A mapping of metadata keys to lists of values.
+            key (str): The header key.
+            value (str): The header value.
 
         Returns:
             None
         """
-        self._trailing_metadata = metadata
+        if self._response_headers is None:
+            self._response_headers = []
+        self._response_headers.append((key, value))
+
+    def response_trailers(self) -> Iterable[tuple[str, str]]:
+        """
+        Returns the response trailers that will be sent after the response.
+        """
+        if self._response_trailers is None:
+            return ()
+        return self._response_trailers
+
+    def add_response_trailer(self, key: str, value: str) -> None:
+        """
+        Add a response trailer to send after the response.
+
+        Args:
+            key (str): The header key.
+            value (str): The header value.
+
+        Returns:
+            None
+        """
+        if self._response_trailers is None:
+            self._response_trailers = []
+        self._response_trailers.append((key, value))
 
     def time_remaining(self) -> Union[float, None]:
         """
@@ -333,12 +201,3 @@ class ConnecpyServiceContext:
         if self._timeout_sec is None:
             return None
         return self._timeout_sec - (time.time() - self._start_time)
-
-    def trailing_metadata(self) -> Mapping[str, List[str]]:
-        """
-        Returns the trailing metadata associated with the context.
-
-        :return: A mapping of metadata keys to lists of metadata values.
-        :rtype: Mapping[str, List[str]]
-        """
-        return self._trailing_metadata

--- a/src/connecpy/encoding.py
+++ b/src/connecpy/encoding.py
@@ -48,7 +48,7 @@ def json_encoder(value: Any, data_obj: Any) -> Tuple[bytes, Dict[str, List[str]]
             data = value
         return (
             json.dumps(data).encode("utf-8"),
-            {"Content-Type": ["application/json"]},
+            {"content-type": ["application/json"]},
         )
     except Exception as e:
         raise exceptions.ConnecpyServerException(
@@ -64,7 +64,7 @@ def proto_encoder(
     try:
         return (
             value.SerializeToString(),
-            {"Content-Type": ["application/proto"]},
+            {"content-type": ["application/proto"]},
         )
     except Exception as e:
         raise exceptions.ConnecpyServerException(

--- a/src/connecpy/shared_client.py
+++ b/src/connecpy/shared_client.py
@@ -1,4 +1,5 @@
 import base64
+from contextvars import ContextVar, Token
 from typing import Iterable, Optional
 
 from httpx import Headers
@@ -66,3 +67,73 @@ def prepare_get_params(request_data, headers):
     if "content-encoding" in headers:
         params["compression"] = headers.pop("content-encoding")
     return params
+
+
+_current_response = ContextVar["Response"]("connecpy_current_response")
+
+
+def handle_response_headers(headers: Headers):
+    response = _current_response.get(None)
+    if not response:
+        return
+
+    response_headers: list[tuple[str, str]] = []
+    response_trailers: list[tuple[str, str]] = []
+    for key, value in headers.multi_items():
+        if key.lower().startswith("trailer-"):
+            key = key[len("trailer-") :]
+            obj = response_trailers
+        else:
+            obj = response_headers
+        obj.append((key, value))
+    if response_headers:
+        response._headers = Headers(response_headers)
+    if response_trailers:
+        response._trailers = Headers(response_trailers)
+
+
+class Response:
+    """
+    Response data separate from the message payload.
+
+    Commonly, RPC client invocations only need the message payload and do not need to
+    directly read other data such as headers or trailers. In cases where they are needed,
+    initialize this class in a context manager to access the response headers and trailers
+    for the invocation made within the context.
+
+    Example:
+        with Response() as resp_data:
+            resp = client.MakeHat(Size(inches=10))
+            do_something_with_response_payload(resp)
+            check_response_headers(resp_data.headers())
+            check_response_trailers(resp_data.trailers())
+    """
+
+    _headers: Optional[Headers] = None
+    _trailers: Optional[Headers] = None
+    _token: Optional[Token["Response"]] = None
+
+    def __enter__(self) -> "Response":
+        self._token = _current_response.set(self)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._token:
+            try:
+                _current_response.reset(self._token)
+            except Exception:
+                # Normal usage with context manager will always work but it is
+                # theoretically possible for user to move to another thread
+                # and this fails, it is fine to ignore it.
+                pass
+        self._token = None
+
+    def headers(self) -> Headers:
+        """Returns the response headers."""
+        return self._headers or Headers()
+
+    def trailers(self) -> Headers:
+        """Returns the response trailers."""
+        if self._trailers is None:
+            return Headers()
+        return self._trailers

--- a/src/connecpy/wsgi.py
+++ b/src/connecpy/wsgi.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from http import HTTPStatus
-from typing import List, Mapping, Optional, Union
+from typing import List, Mapping, Optional
 import base64
 from urllib.parse import parse_qs
 from functools import partial
@@ -46,58 +46,6 @@ def extract_metadata_from_query_params(query_string: str) -> dict:
     return parse_qs(query_string) if query_string else {}
 
 
-def reflect_header(key: str, value: Union[str, List[str]], headers: list) -> None:
-    """Add a header to the WSGI response headers list.
-
-    Args:
-        key: Header name
-        value: Header value or list of values
-        headers: List of header tuples to append to
-    """
-    if isinstance(value, list):
-        if value:  # Only add if there are values
-            headers.append((key, str(value[0])))
-    else:
-        headers.append((key, str(value)))
-
-
-def format_response_headers(
-    base_headers: dict, compression_info: dict, trailers: dict
-) -> list[tuple[str, str]]:
-    """Format response headers into WSGI compatible format.
-
-    Args:
-        base_headers (dict): Base headers from encoder
-        compression_info (dict): Compression related headers
-        trailers (dict): Trailer headers
-
-    Returns:
-        list[tuple[str, str]]: List of header tuples in WSGI format
-    """
-    # Combine all headers
-    headers = {}
-
-    # Start with base headers
-    for key, value in base_headers.items():
-        if isinstance(value, list):
-            headers[key] = value[0] if value else ""
-        else:
-            headers[key] = str(value)
-
-    # Add compression headers
-    headers.update(compression_info)
-
-    # Add trailers with prefix
-    for key, value in trailers.items():
-        if isinstance(value, list):
-            headers[f"trailer-{key.lower()}"] = value[0] if value else ""
-        else:
-            headers[f"trailer-{key.lower()}"] = str(value)
-
-    # Convert to WSGI format
-    return [(str(k).lower(), str(v)) for k, v in headers.items()]
-
-
 def validate_request_headers(headers: dict) -> tuple[str, str]:
     """Validate and normalize request headers.
 
@@ -127,10 +75,10 @@ def validate_request_headers(headers: dict) -> tuple[str, str]:
 
 
 def prepare_response_headers(
-    base_headers: dict,
+    base_headers: dict[str, list[str]],
     selected_encoding: str,
     compressed_size: Optional[int] = None,
-) -> tuple[dict, bool]:
+) -> tuple[dict[str, list[str]], bool]:
     """Prepare response headers and determine if compression should be used.
 
     Args:
@@ -145,13 +93,13 @@ def prepare_response_headers(
     use_compression = False
 
     if "content-type" not in headers:
-        headers["content-type"] = "application/proto"
+        headers["content-type"] = ["application/proto"]
 
     if selected_encoding != "identity" and compressed_size is not None:
-        headers["content-encoding"] = selected_encoding
+        headers["content-encoding"] = [selected_encoding]
         use_compression = True
 
-    headers["vary"] = "Accept-Encoding"
+    headers["vary"] = ["Accept-Encoding"]
     return headers, use_compression
 
 
@@ -241,7 +189,7 @@ class ConnecpyWSGIApp(base.ConnecpyBaseApp):
             # Default to proto if not specified
             if content_type not in ["application/json", "application/proto"]:
                 content_type = "application/proto"
-                ctx = context.ConnecpyServiceContext(
+                ctx = context.ServiceContext(
                     environ.get("REMOTE_ADDR"),
                     convert_to_mapping({"content-type": ["application/proto"]}),
                 )
@@ -337,7 +285,7 @@ class ConnecpyWSGIApp(base.ConnecpyBaseApp):
             request_headers = normalize_wsgi_headers(environ)
             request_method = environ.get("REQUEST_METHOD")
             if request_method == "POST":
-                ctx = context.ConnecpyServiceContext(
+                ctx = context.ServiceContext(
                     environ.get("REMOTE_ADDR"), convert_to_mapping(request_headers)
                 )
             else:
@@ -345,7 +293,7 @@ class ConnecpyWSGIApp(base.ConnecpyBaseApp):
                 metadata.update(
                     extract_metadata_from_query_params(environ.get("QUERY_STRING"))
                 )
-                ctx = context.ConnecpyServiceContext(
+                ctx = context.ServiceContext(
                     environ.get("REMOTE_ADDR"), convert_to_mapping(metadata)
                 )
             endpoint = self._get_endpoint(environ.get("PATH_INFO"))
@@ -385,13 +333,15 @@ class ConnecpyWSGIApp(base.ConnecpyBaseApp):
             )
 
             # Convert headers to WSGI format
-            wsgi_headers = []
-            for key, value in response_headers.items():
-                if isinstance(value, list):
-                    if value:  # Only add if there are values
-                        wsgi_headers.append((key, str(value[0])))
-                else:
-                    wsgi_headers.append((key, str(value)))
+            wsgi_headers: list[tuple[str, str]] = []
+            for key, values in response_headers.items():
+                for value in values:
+                    wsgi_headers.append((key.lower(), value))
+            wsgi_headers.extend(
+                (key.lower(), value) for key, value in ctx.response_headers()
+            )
+            for key, value in ctx.response_trailers():
+                wsgi_headers.append((f"trailer-{key.lower()}", value))
 
             start_response("200 OK", wsgi_headers)
             final_response = compressed_bytes if use_compression else res_bytes


### PR DESCRIPTION
Currently response headers and trailers cannot be accessed from the client as expected by the connect protocol. This provides access via a context manager - I considered following the connect-es pattern of `on_header` but felt that callbacks like that aren't idiomatic in Python. Let me know if this pattern looks fine instead.

I also changed `trailing_metadata` to `headers` / `trailers` which I think are the terms that connect uses instead of gRPC's terms.

Also cleaned up changes missing from previous `ClientContext` cleanup by actually removing that class, and fixing docs about it.