### PR TITLE
feat: validate content encoding in client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,12 @@ jobs:
       - name: run python tests
         run: uv run pytest
 
+      - name: run tests with minimal dependencies
+        run: |
+          uv sync --exact
+          uv run pytest
+        working-directory: noextras
+
       - name: run Go tests
         run: go test ./...
         working-directory: protoc-gen-connecpy

--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "connecpy-example"
+name = "example"
 version = "0.1.0"
 
 dependencies = [

--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "example"
+name = "connecpy-example"
 version = "0.1.0"
 
 dependencies = [

--- a/noextras/pyproject.toml
+++ b/noextras/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "noextras"
+version = "0.1.0"
+
+dependencies = [
+    "connecpy",
+    "example",
+    "pytest>=8.3.4",
+    "pytest-asyncio>=0.25.2",
+]
+
+[tool.ruff]
+extend = "../pyproject.toml"

--- a/noextras/pyproject.toml
+++ b/noextras/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
-name = "noextras"
+name = "connecpy-noextras"
 version = "0.1.0"
 
 dependencies = [
     "connecpy",
-    "example",
+    "connecpy-example",
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.2",
 ]

--- a/noextras/test/test_compression_default.py
+++ b/noextras/test/test_compression_default.py
@@ -1,0 +1,98 @@
+from httpx import (
+    ASGITransport,
+    AsyncClient,
+    Client,
+    WSGITransport,
+)
+import pytest
+from connecpy.errors import Errors
+from connecpy.exceptions import ConnecpyServerException
+from example.haberdasher_connecpy import (
+    Haberdasher,
+    HaberdasherASGIApplication,
+    HaberdasherClient,
+    HaberdasherClientSync,
+    HaberdasherSync,
+    HaberdasherWSGIApplication,
+)
+from example.haberdasher_pb2 import Hat, Size
+
+
+@pytest.mark.parametrize("compression", ["gzip", "identity", None])
+def test_roundtrip_sync(compression: str):
+    class RoundtripHaberdasherSync(HaberdasherSync):
+        def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+    app = HaberdasherWSGIApplication(RoundtripHaberdasherSync())
+    with HaberdasherClientSync(
+        "http://localhost",
+        session=Client(transport=WSGITransport(app=app)),
+        send_compression=compression,
+        accept_compression=[compression] if compression else None,
+    ) as client:
+        response = client.MakeHat(request=Size(inches=10))
+    assert response.size == 10
+    assert response.color == "green"
+
+
+@pytest.mark.parametrize("compression", ["gzip", "identity"])
+@pytest.mark.asyncio
+async def test_roundtrip_async(compression: str):
+    class DetailsHaberdasher(Haberdasher):
+        async def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+    app = HaberdasherASGIApplication(DetailsHaberdasher())
+    transport = ASGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete
+    async with HaberdasherClient(
+        "http://localhost",
+        session=AsyncClient(transport=transport),
+        send_compression=compression,
+        accept_compression=[compression] if compression else None,
+    ) as client:
+        response = await client.MakeHat(request=Size(inches=10))
+    assert response.size == 10
+    assert response.color == "green"
+
+
+@pytest.mark.parametrize("compression", ["br", "zstd"])
+def test_invalid_compression_sync(compression: str):
+    class RoundtripHaberdasherSync(HaberdasherSync):
+        def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+    app = HaberdasherWSGIApplication(RoundtripHaberdasherSync())
+    with (
+        HaberdasherClientSync(
+            "http://localhost",
+            session=Client(transport=WSGITransport(app=app)),
+            send_compression=compression,
+            accept_compression=[compression] if compression else None,
+        ) as client,
+        pytest.raises(ConnecpyServerException) as exc_info,
+    ):
+        client.MakeHat(request=Size(inches=10))
+    assert exc_info.value.code == Errors.Unavailable
+    assert exc_info.value.message == f"Unsupported compression method: {compression}"
+
+
+@pytest.mark.parametrize("compression", ["br", "zstd"])
+@pytest.mark.asyncio
+async def test_invalid_compression_async(compression: str):
+    class DetailsHaberdasher(Haberdasher):
+        async def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+    app = HaberdasherASGIApplication(DetailsHaberdasher())
+    transport = ASGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete
+    async with HaberdasherClient(
+        "http://localhost",
+        session=AsyncClient(transport=transport),
+        send_compression=compression,
+        accept_compression=[compression] if compression else None,
+    ) as client:
+        with pytest.raises(ConnecpyServerException) as exc_info:
+            await client.MakeHat(request=Size(inches=10))
+    assert exc_info.value.code == Errors.Unavailable
+    assert exc_info.value.message == f"Unsupported compression method: {compression}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license-files = ["LICENSE"]
 dev-dependencies = [
     "asgiref",
     "brotli",
-    "connecpy-example",
+    "example",
     "flask",
     "grpcio",
     "grpcio-tools",
@@ -32,6 +32,11 @@ dev-dependencies = [
 [build-system]
 requires = ["uv_build>=0.7.21,<0.8.0"]
 build-backend = "uv_build"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "test",
+]
 
 [tool.ruff]
 # Don't run ruff on generated code from external plugins.
@@ -50,8 +55,11 @@ exclude = [
 ]
 
 [tool.uv.workspace]
-members = ["example"]
+members = [
+    "example", 
+    "noextras",
+]
 
 [tool.uv.sources]
 connecpy = { workspace = true }
-connecpy-example = { workspace = true }
+example = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license-files = ["LICENSE"]
 dev-dependencies = [
     "asgiref",
     "brotli",
-    "example",
+    "connecpy-example",
     "flask",
     "grpcio",
     "grpcio-tools",
@@ -62,4 +62,4 @@ members = [
 
 [tool.uv.sources]
 connecpy = { workspace = true }
-example = { workspace = true }
+connecpy-example = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,21 +5,18 @@ description = "Code generator, server library and client library for the Connect
 authors = [
     { name = "Yasushi Itoh" }
 ]
+requires-python = ">= 3.10"
 dependencies = [
     "httpx",
     "protobuf",
-    "zstd-asgi>=0.2",
-    "brotli-asgi>=1.4.0",
-    "brotli>=1.1.0",
-    "zstandard>=0.22.0",
 ]
 readme = "README.md"
 license-files = ["LICENSE"]
-requires-python = ">= 3.10"
 
 [tool.uv]
 dev-dependencies = [
     "asgiref",
+    "brotli",
     "connecpy-example",
     "flask",
     "grpcio",
@@ -29,7 +26,7 @@ dev-dependencies = [
     "pytest>=8.3.4",
     "pytest-asyncio>=0.25.2",
     "ruff>=0.9.4",
-    "zstd-asgi>=0.2",
+    "zstandard",
 ]
 
 [build-system]

--- a/src/connecpy/_client_async.py
+++ b/src/connecpy/_client_async.py
@@ -97,10 +97,9 @@ class ConnecpyClient:
             request_data = self._codec.encode(request)
             client = session or self._session
 
-            if "content-encoding" in request_headers:
-                request_data, request_headers = _client_shared.compress_request(
-                    request_data, request_headers
-                )
+            request_data = _client_shared.maybe_compress_request(
+                request_data, request_headers
+            )
 
             if method == "GET":
                 params = _client_shared.prepare_get_params(
@@ -127,6 +126,9 @@ class ConnecpyClient:
                     timeout_s,
                 )
 
+            _client_shared.validate_response_content_encoding(
+                resp.headers.get("content-encoding", "")
+            )
             _client_shared.validate_response_content_type(
                 self._codec.name(),
                 resp.status_code,

--- a/src/connecpy/_client_sync.py
+++ b/src/connecpy/_client_sync.py
@@ -93,10 +93,9 @@ class ConnecpyClientSync:
 
         try:
             request_data = self._codec.encode(request)
-            if "content-encoding" in request_headers:
-                request_data, request_headers = _client_shared.compress_request(
-                    request_data, request_headers
-                )
+            request_data = _client_shared.maybe_compress_request(
+                request_data, request_headers
+            )
 
             if method == "GET":
                 params = _client_shared.prepare_get_params(
@@ -117,6 +116,9 @@ class ConnecpyClientSync:
                     **request_args,
                 )
 
+            _client_shared.validate_response_content_encoding(
+                resp.headers.get("content-encoding", "")
+            )
             _client_shared.validate_response_content_type(
                 self._codec.name(),
                 resp.status_code,

--- a/src/connecpy/_compression.py
+++ b/src/connecpy/_compression.py
@@ -1,8 +1,6 @@
 from collections.abc import KeysView
 from typing import Optional, Protocol
 import gzip
-import brotli
-import zstandard
 
 
 class Compression(Protocol):

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -173,6 +173,13 @@ _http_errors = [
         "Bad Gateway",
         id="bad json",
     ),
+    p(
+        200,
+        {"text": "weird encoding", "headers": {"content-encoding": "weird"}},
+        Errors.Internal,
+        "unknown encoding 'weird'; accepted encodings are gzip, br, zstd, identity",
+        id="bad encoding",
+    ),
 ]
 
 

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -39,7 +39,7 @@ def test_roundtrip_sync(proto_json: bool, compression: str):
 @pytest.mark.parametrize("proto_json", [False, True])
 @pytest.mark.parametrize("compression", ["gzip", "br", "zstd", "identity"])
 @pytest.mark.asyncio
-async def test_details_async(proto_json: bool, compression: str):
+async def test_roundtrip_async(proto_json: bool, compression: str):
     class DetailsHaberdasher(Haberdasher):
         async def MakeHat(self, req, ctx):
             return Hat(size=req.inches, color="green")

--- a/uv.lock
+++ b/uv.lock
@@ -5,8 +5,8 @@ requires-python = ">=3.10"
 [manifest]
 members = [
     "connecpy",
-    "example",
-    "noextras",
+    "connecpy-example",
+    "connecpy-noextras",
 ]
 
 [[package]]
@@ -215,7 +215,7 @@ dependencies = [
 dev = [
     { name = "asgiref" },
     { name = "brotli" },
-    { name = "example" },
+    { name = "connecpy-example" },
     { name = "flask" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
@@ -237,7 +237,7 @@ requires-dist = [
 dev = [
     { name = "asgiref" },
     { name = "brotli" },
-    { name = "example", editable = "example" },
+    { name = "connecpy-example", editable = "example" },
     { name = "flask" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
@@ -250,7 +250,7 @@ dev = [
 ]
 
 [[package]]
-name = "example"
+name = "connecpy-example"
 version = "0.1.0"
 source = { editable = "example" }
 dependencies = [
@@ -266,6 +266,25 @@ requires-dist = [
     { name = "grpcio" },
     { name = "protobuf" },
     { name = "starlette" },
+]
+
+[[package]]
+name = "connecpy-noextras"
+version = "0.1.0"
+source = { virtual = "noextras" }
+dependencies = [
+    { name = "connecpy" },
+    { name = "connecpy-example" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "connecpy", editable = "." },
+    { name = "connecpy-example", editable = "example" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
 
 [[package]]
@@ -544,25 +563,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2b/04e0e7f7305fe2ba30fd4610bfb432516e0f65379fe6c2902f4b7b1ad436/nodejs_wheel_binaries-22.17.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715f413c81500f0770ea8936ef1fc2529b900da8054cbf6da67cec3ee308dc76", size = 60830079, upload-time = "2025-06-29T20:24:12.21Z" },
     { url = "https://files.pythonhosted.org/packages/ce/67/12070b24b88040c2d694883f3dcb067052f748798f4c63f7c865769a5747/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_amd64.whl", hash = "sha256:51165630493c8dd4acfe1cae1684b76940c9b03f7f355597d55e2d056a572ddd", size = 40117877, upload-time = "2025-06-29T20:24:17.51Z" },
     { url = "https://files.pythonhosted.org/packages/2e/ec/53ac46af423527c23e40c7343189f2bce08a8337efedef4d8a33392cee23/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_arm64.whl", hash = "sha256:fae56d172227671fccb04461d3cd2b26a945c6c7c7fc29edb8618876a39d8b4a", size = 38865278, upload-time = "2025-06-29T20:24:21.065Z" },
-]
-
-[[package]]
-name = "noextras"
-version = "0.1.0"
-source = { virtual = "noextras" }
-dependencies = [
-    { name = "connecpy" },
-    { name = "example" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "connecpy", editable = "." },
-    { name = "example", editable = "example" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5,7 +5,8 @@ requires-python = ">=3.10"
 [manifest]
 members = [
     "connecpy",
-    "connecpy-example",
+    "example",
+    "noextras",
 ]
 
 [[package]]
@@ -214,7 +215,7 @@ dependencies = [
 dev = [
     { name = "asgiref" },
     { name = "brotli" },
-    { name = "connecpy-example" },
+    { name = "example" },
     { name = "flask" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
@@ -236,7 +237,7 @@ requires-dist = [
 dev = [
     { name = "asgiref" },
     { name = "brotli" },
-    { name = "connecpy-example", editable = "example" },
+    { name = "example", editable = "example" },
     { name = "flask" },
     { name = "grpcio" },
     { name = "grpcio-tools" },
@@ -249,7 +250,7 @@ dev = [
 ]
 
 [[package]]
-name = "connecpy-example"
+name = "example"
 version = "0.1.0"
 source = { editable = "example" }
 dependencies = [
@@ -543,6 +544,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2b/04e0e7f7305fe2ba30fd4610bfb432516e0f65379fe6c2902f4b7b1ad436/nodejs_wheel_binaries-22.17.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715f413c81500f0770ea8936ef1fc2529b900da8054cbf6da67cec3ee308dc76", size = 60830079, upload-time = "2025-06-29T20:24:12.21Z" },
     { url = "https://files.pythonhosted.org/packages/ce/67/12070b24b88040c2d694883f3dcb067052f748798f4c63f7c865769a5747/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_amd64.whl", hash = "sha256:51165630493c8dd4acfe1cae1684b76940c9b03f7f355597d55e2d056a572ddd", size = 40117877, upload-time = "2025-06-29T20:24:17.51Z" },
     { url = "https://files.pythonhosted.org/packages/2e/ec/53ac46af423527c23e40c7343189f2bce08a8337efedef4d8a33392cee23/nodejs_wheel_binaries-22.17.0-py2.py3-none-win_arm64.whl", hash = "sha256:fae56d172227671fccb04461d3cd2b26a945c6c7c7fc29edb8618876a39d8b4a", size = 38865278, upload-time = "2025-06-29T20:24:21.065Z" },
+]
+
+[[package]]
+name = "noextras"
+version = "0.1.0"
+source = { virtual = "noextras" }
+dependencies = [
+    { name = "connecpy" },
+    { name = "example" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "connecpy", editable = "." },
+    { name = "example", editable = "example" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.2" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -115,19 +115,6 @@ wheels = [
 ]
 
 [[package]]
-name = "brotli-asgi"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "brotli" },
-    { name = "starlette" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/6f/fce5d382b5e9de3dd5d65888b5c278b02ebb228cb2f46f336cefd8553b84/brotli-asgi-1.4.0.tar.gz", hash = "sha256:e2d6eca4b97af19716af05bbe0d4d79cffb0b0947100c188da9ed089f5b7bc2f", size = 5708, upload-time = "2023-04-24T23:52:38.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/36/2f469407b7d6cb254aaa1471a0df0b9a65ed59380941d7003b488530d18b/brotli_asgi-1.4.0-py3-none-any.whl", hash = "sha256:bc18bcb20803dc9d11abdd14ac4242f2f09ebb9d2a67f4d3a7fe4cb8bedcd226", size = 4590, upload-time = "2023-04-24T23:52:35.477Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -195,28 +182,10 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
-]
-
-[[package]]
-name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -237,17 +206,14 @@ name = "connecpy"
 version = "1.5.0"
 source = { editable = "." }
 dependencies = [
-    { name = "brotli" },
-    { name = "brotli-asgi" },
     { name = "httpx" },
     { name = "protobuf" },
-    { name = "zstandard" },
-    { name = "zstd-asgi" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "asgiref" },
+    { name = "brotli" },
     { name = "connecpy-example" },
     { name = "flask" },
     { name = "grpcio" },
@@ -257,22 +223,19 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
-    { name = "zstd-asgi" },
+    { name = "zstandard" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "brotli", specifier = ">=1.1.0" },
-    { name = "brotli-asgi", specifier = ">=1.4.0" },
     { name = "httpx" },
     { name = "protobuf" },
-    { name = "zstandard", specifier = ">=0.22.0" },
-    { name = "zstd-asgi", specifier = ">=0.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "asgiref" },
+    { name = "brotli" },
     { name = "connecpy-example", editable = "example" },
     { name = "flask" },
     { name = "grpcio" },
@@ -282,7 +245,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-asyncio", specifier = ">=0.25.2" },
     { name = "ruff", specifier = ">=0.9.4" },
-    { name = "zstd-asgi", specifier = ">=0.2" },
+    { name = "zstandard" },
 ]
 
 [[package]]
@@ -319,9 +282,7 @@ version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "markupsafe" },
@@ -472,18 +433,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -569,16 +518,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ea/9b1530c3fdeeca613faeb0fb5cbcf2389d816072fab72a71b45749ef6062/MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a", size = 14344, upload-time = "2024-10-18T15:21:43.721Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/c2/fbdbfe48848e7112ab05e627e718e854d20192b674952d9042ebd8c9e5de/MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff", size = 12389, upload-time = "2024-10-18T15:21:44.666Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/25/7a7c6e4dbd4f867d95d94ca15449e91e52856f6ed1905d58ef1de5e211d0/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13", size = 21607, upload-time = "2024-10-18T15:21:45.452Z" },
-    { url = "https://files.pythonhosted.org/packages/53/8f/f339c98a178f3c1e545622206b40986a4c3307fe39f70ccd3d9df9a9e425/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144", size = 20728, upload-time = "2024-10-18T15:21:46.295Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/03/8496a1a78308456dbd50b23a385c69b41f2e9661c67ea1329849a598a8f9/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29", size = 20826, upload-time = "2024-10-18T15:21:47.134Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/cf/0a490a4bd363048c3022f2f475c8c05582179bb179defcee4766fb3dcc18/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0", size = 21843, upload-time = "2024-10-18T15:21:48.334Z" },
-    { url = "https://files.pythonhosted.org/packages/19/a3/34187a78613920dfd3cdf68ef6ce5e99c4f3417f035694074beb8848cd77/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0", size = 21219, upload-time = "2024-10-18T15:21:49.587Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946, upload-time = "2024-10-18T15:21:50.441Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063, upload-time = "2024-10-18T15:21:51.385Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506, upload-time = "2024-10-18T15:21:52.974Z" },
 ]
 
 [[package]]
@@ -819,15 +758,6 @@ wheels = [
 ]
 
 [[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
-]
-
-[[package]]
 name = "zstandard"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -900,17 +830,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/90/2633473864f67a15526324b007a9f96c96f56d5f32ef2a56cc12f9548723/zstandard-0.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ce8b52c5987b3e34d5674b0ab529a4602b632ebab0a93b07bfb4dfc8f8a33", size = 5191299, upload-time = "2024-07-15T00:16:49.053Z" },
     { url = "https://files.pythonhosted.org/packages/b0/4c/315ca5c32da7e2dc3455f3b2caee5c8c2246074a61aac6ec3378a97b7136/zstandard-0.23.0-cp313-cp313-win32.whl", hash = "sha256:a9b07268d0c3ca5c170a385a0ab9fb7fdd9f5fd866be004c4ea39e44edce47dd", size = 430862, upload-time = "2024-07-15T00:16:51.003Z" },
     { url = "https://files.pythonhosted.org/packages/a2/bf/c6aaba098e2d04781e8f4f7c0ba3c7aa73d00e4c436bcc0cf059a66691d1/zstandard-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:f3513916e8c645d0610815c257cbfd3242adfd5c4cfa78be514e5a3ebb42a41b", size = 495578, upload-time = "2024-07-15T00:16:53.135Z" },
-]
-
-[[package]]
-name = "zstd-asgi"
-version = "0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "starlette" },
-    { name = "zstandard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/6d/7f9dc583d2c08febb0b7650076dae055271b949834bbb193ff3446a7b36f/zstd-asgi-0.2.tar.gz", hash = "sha256:c578f5741598e61039f302cfe64603ed6f8e662350af30f6bf6ddcb870c91089", size = 5193, upload-time = "2023-12-17T12:51:09.04Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/f1/eb6c18b9fec0b89fba51df0820b012f6c1340f467fdb3494bcfa2796b9ed/zstd_asgi-0.2-py3-none-any.whl", hash = "sha256:f4b8a3a39b7a941f3a75e6d316202d28b9d4fc8e22384403a6f2ff6ae6133b69", size = 4241, upload-time = "2023-12-17T12:51:07.479Z" },
 ]


### PR DESCRIPTION
The main feature of this is to validate content encoding, so if a bad one is returned from server we throw an error instead of trying to parse as identity (httpx ignores unknown encoding it seems). This passes another conformance test.

Also refactors compression to look closer to Codec, and makes brotli and zstandard optional dependencies which I think is good practice and matches other connect implementations