### PR TITLE
chore: rename ConnecpyServerException to ConnecpyException

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ go install github.com/i2y/connecpy/protoc-gen-connecpy@latest
 
 Additionally, please add the connecpy package to your project using your preferred package manager. For instance, with [uv](https://docs.astral.sh/uv/), use the command:
 
-
 ```sh
 uv add connecpy
 ```
@@ -25,9 +24,7 @@ or
 pip install connecpy
 ```
 
-
 To run the server, you'll need one of the following: [Uvicorn](https://www.uvicorn.org/), [Daphne](https://github.com/django/daphne), or [Hypercorn](https://gitlab.com/pgjones/hypercorn). If your goal is to support both HTTP/1.1 and HTTP/2, you should opt for either Daphne or Hypercorn. Additionally, to test the server, you might need a client command, such as [buf](https://buf.build/docs/installation).
-
 
 ## Generate and run
 
@@ -81,9 +78,11 @@ app = haberdasher_connecpy.HaberdasherWSGIApplication(
 ```
 
 Run the server with
+
 ```sh
 uvicorn --port=3000 server:app
 ```
+
 or
 
 ```sh
@@ -104,7 +103,7 @@ import asyncio
 
 import httpx
 
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 
 import haberdasher_connecpy, haberdasher_pb2
 
@@ -129,7 +128,7 @@ async def main():
         if not response.HasField("name"):
             print("We didn't get a name!")
         print(response)
-    except ConnecpyServerException as e:
+    except ConnecpyException as e:
         print(e.code, e.message, e.to_dict())
     finally:
         # Close the session (could also use a context manager)
@@ -142,6 +141,7 @@ if __name__ == "__main__":
 ```
 
 Example output :
+
 ```
 size: 12
 color: "black"
@@ -152,7 +152,7 @@ name: "bowler"
 
 ```python
 # client.py
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 
 import haberdasher_connecpy, haberdasher_pb2
 
@@ -170,7 +170,7 @@ def main():
             if not response.HasField("name"):
                 print("We didn't get a name!")
             print(response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print(e.code, e.message, e.to_dict())
 
 
@@ -183,42 +183,49 @@ if __name__ == "__main__":
 Of course, you can use any HTTP client to make requests to a Connecpy server. For example, commands like `curl` or `buf curl` can be used, as well as HTTP client libraries such as `requests`, `httpx`, `aiohttp`, and others. The examples below use `curl` and `buf curl`.
 
 Content-Type: application/proto, HTTP/1.1
+
 ```sh
 buf curl --data '{"inches": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat --schema ./haberdasher.proto
 ```
 
 On Windows, Content-Type: application/proto, HTTP/1.1
+
 ```sh
 buf curl --data '{\"inches\": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat --schema .\haberdasher.proto
 ```
 
 Content-Type: application/proto, HTTP/2
+
 ```sh
 buf curl --data '{"inches": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat --http2-prior-knowledge --schema ./haberdasher.proto
 ```
 
 On Windows, Content-Type: application/proto, HTTP/2
+
 ```sh
 buf curl --data '{\"inches\": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat --http2-prior-knowledge --schema .\haberdasher.proto
 ```
 
-
 Content-Type: application/json, HTTP/1.1
+
 ```sh
 curl -X POST -H "Content-Type: application/json" -d '{"inches": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat
 ```
 
 On Windows, Content-Type: application/json, HTTP/1.1
+
 ```sh
 curl -X POST -H "Content-Type: application/json" -d '{\"inches\": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat
 ```
 
 Content-Type: application/json, HTTP/2
+
 ```sh
 curl --http2-prior-knowledge -X POST -H "Content-Type: application/json" -d '{"inches": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat
 ```
 
 On Windows, Content-Type: application/json, HTTP/2
+
 ```sh
 curl --http2-prior-knowledge -X POST -H "Content-Type: application/json" -d '{\"inches\": 12}' -v http://localhost:3000/i2y.connecpy.example.Haberdasher/MakeHat
 ```
@@ -239,11 +246,13 @@ Connecpy supports various compression methods for both GET and POST requests/res
 - identity (no compression)
 
 For GET requests, specify the compression method using the `compression` query parameter:
+
 ```sh
 curl "http://localhost:3000/service/method?compression=gzip&message=..."
 ```
 
 For POST requests, use the `Content-Encoding` header:
+
 ```sh
 curl -H "Content-Encoding: br" -d '{"data": "..."}' http://localhost:3000/service/method
 ```
@@ -259,6 +268,7 @@ The compression handling is built into both ASGI and WSGI applications. You don'
 ### Client-side
 
 For synchronous clients:
+
 ```python
 
 with HaberdasherClient(server_url) as client:
@@ -270,6 +280,7 @@ with HaberdasherClient(server_url) as client:
 ```
 
 For async clients:
+
 ```python
 async with HaberdasherClientSync(server_url) as client:
     response = client.MakeHat(
@@ -280,6 +291,7 @@ async with HaberdasherClientSync(server_url) as client:
 ```
 
 Using GET requests with compression:
+
 ```python
 response = client.MakeHat(
     request=request_obj,
@@ -345,11 +357,10 @@ service = haberdasher_connecpy.HaberdasherASGIApplication(HaberdasherService())
 
 Btw, `ServerInterceptor`'s `intercept` method has compatible signature as `intercept` method of [grpc_interceptor.server.AsyncServerInterceptor](https://grpc-interceptor.readthedocs.io/en/latest/#async-server-interceptors), so you might be able to convert Connecpy interceptors to gRPC interceptors by just changing the import statement and the parent class.
 
-
 ### gRPC Compatibility
+
 In Connecpy, unlike connect-go, it is not possible to simultaneously support both gRPC and Connect RPC on the same server and port. In addition to it, Connecpy itself doesn't support gRPC. However, implementing a gRPC server using the same service code used for Connecpy server is feasible, as shown below. This is possible because the type signature of the service class in Connecpy is compatible with type signature gRPC framework requires.
 The example below uses [grpc.aio](https://grpc.github.io/grpc/python/grpc_asyncio.html) and there are in [example directory](example/README.md).
-
 
 ```python
 # grpc_server.py

--- a/conformance/test/client.py
+++ b/conformance/test/client.py
@@ -8,7 +8,7 @@ import httpx
 from _util import create_standard_streams
 from connecpy.client import ResponseMetadata
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connectrpc.conformance.v1.client_compat_pb2 import (
     ClientCompatRequest,
     ClientCompatResponse,
@@ -229,7 +229,7 @@ async def _run_test(
                                 task.cancel()
                             client_response = await task
                 test_response.response.payloads.add().MergeFrom(client_response.payload)
-            except ConnecpyServerException as e:
+            except ConnecpyException as e:
                 test_response.response.error.code = _convert_code(e.code)
                 test_response.response.error.message = e.message
                 test_response.response.error.details.extend(e.details)

--- a/conformance/test/connectrpc/conformance/v1/service_connecpy.py
+++ b/conformance/test/connectrpc/conformance/v1/service_connecpy.py
@@ -8,7 +8,7 @@ import httpx
 
 from connecpy.client import ConnecpyClient, ConnecpyClientSync, RequestHeaders
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
@@ -25,54 +25,42 @@ class ConformanceService(Protocol):
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def ServerStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def ClientStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def BidiStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def Unimplemented(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def IdempotentUnary(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
@@ -291,54 +279,42 @@ class ConformanceServiceSync(Protocol):
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def ServerStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def ClientStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def BidiStream(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def Unimplemented(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def IdempotentUnary(
         self,
         req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
         ctx: ServiceContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class ConformanceServiceWSGIApplication(ConnecpyWSGIApplication):

--- a/conformance/test/server.py
+++ b/conformance/test/server.py
@@ -7,7 +7,7 @@ from typing import Literal, TypeVar
 
 from _util import create_standard_streams
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import ServiceContext
 from connectrpc.conformance.v1.config_pb2 import Code as ConformanceCode
 from connectrpc.conformance.v1.server_compat_pb2 import (
@@ -102,7 +102,7 @@ async def _handle_unary_response(
     request_info = _create_request_info(ctx, reqs)
 
     if definition.WhichOneof("response") == "error":
-        raise ConnecpyServerException(
+        raise ConnecpyException(
             code=_convert_code(definition.error.code),
             message=definition.error.message,
             details=[*definition.error.details, request_info],

--- a/example/example/client.py
+++ b/example/example/client.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import httpx
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 
 from . import haberdasher_connecpy, haberdasher_pb2
 
@@ -29,7 +29,7 @@ async def main():
                     },
                 )
                 print("POST with Zstandard and Brotli compression:", response)
-            except ConnecpyServerException as e:
+            except ConnecpyException as e:
                 print(e.code, e.message)
 
         # Example 2: GET request, receiving Zstandard compressed response
@@ -44,7 +44,7 @@ async def main():
                     use_get=True,  # Enable GET request
                 )
                 print("\nGET with Zstandard compression:", response)
-            except ConnecpyServerException as e:
+            except ConnecpyException as e:
                 print(e.code, e.message)
 
 

--- a/example/example/client_sync.py
+++ b/example/example/client_sync.py
@@ -1,4 +1,4 @@
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 
 from . import haberdasher_connecpy, haberdasher_pb2
 
@@ -28,7 +28,7 @@ def main():
                 request=create_large_request(),
             )
             print("POST with gzip compression successful:", response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print("POST with gzip compression failed:", str(e))
 
     # Example 2: POST request with brotli compression (large request)
@@ -44,7 +44,7 @@ def main():
                 request=create_large_request(),
             )
             print("POST with brotli compression successful:", response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print("POST with brotli compression failed:", str(e))
 
     # Example 3: GET request without compression
@@ -58,7 +58,7 @@ def main():
                 use_get=True,
             )
             print("GET without compression successful:", response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print("GET without compression failed:", str(e))
 
     # Example 4: GET request with ztstd compression (large request)
@@ -75,7 +75,7 @@ def main():
                 use_get=True,
             )
             print("GET with zstd compression successful:", response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print("GET with zstd compression failed:", str(e))
 
     # Example 5: Test multiple accepted encodings
@@ -90,7 +90,7 @@ def main():
                 request=create_large_request(),
             )
             print("POST with multiple encodings successful:", response)
-        except ConnecpyServerException as e:
+        except ConnecpyException as e:
             print("POST with multiple encodings failed:", str(e))
 
 

--- a/example/example/haberdasher_connecpy.py
+++ b/example/example/haberdasher_connecpy.py
@@ -8,7 +8,7 @@ import httpx
 
 from connecpy.client import ConnecpyClient, ConnecpyClientSync, RequestHeaders
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
@@ -24,16 +24,12 @@ class Haberdasher(Protocol):
     async def MakeHat(
         self, req: example_dot_haberdasher__pb2.Size, ctx: ServiceContext
     ) -> example_dot_haberdasher__pb2.Hat:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def DoNothing(
         self, req: google_dot_protobuf_dot_empty__pb2.Empty, ctx: ServiceContext
     ) -> google_dot_protobuf_dot_empty__pb2.Empty:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class HaberdasherASGIApplication(ConnecpyASGIApplication):
@@ -125,16 +121,12 @@ class HaberdasherSync(Protocol):
     def MakeHat(
         self, req: example_dot_haberdasher__pb2.Size, ctx: ServiceContext
     ) -> example_dot_haberdasher__pb2.Hat:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def DoNothing(
         self, req: google_dot_protobuf_dot_empty__pb2.Empty, ctx: ServiceContext
     ) -> google_dot_protobuf_dot_empty__pb2.Empty:
-        raise ConnecpyServerException(
-            code=Code.UNIMPLEMENTED, message="Not implemented"
-        )
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
 
 class HaberdasherWSGIApplication(ConnecpyWSGIApplication):

--- a/example/example/service.py
+++ b/example/example/service.py
@@ -1,7 +1,7 @@
 import random
 
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import ServiceContext
 
 from .haberdasher_connecpy import Haberdasher
@@ -12,9 +12,8 @@ class HaberdasherService(Haberdasher):
     async def MakeHat(self, req: Size, ctx: ServiceContext) -> Hat:
         print("remaining_time: ", ctx.timeout_ms())
         if req.inches <= 0:
-            raise ConnecpyServerException(
-                code=Code.INVALID_ARGUMENT,
-                message="inches I can't make a hat that small!",
+            raise ConnecpyException(
+                Code.INVALID_ARGUMENT, "inches I can't make a hat that small!"
             )
         response = Hat(
             size=req.inches,

--- a/example/example/wsgi_service.py
+++ b/example/example/wsgi_service.py
@@ -1,7 +1,7 @@
 import random
 
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import ServiceContext
 
 from .haberdasher_connecpy import HaberdasherSync
@@ -12,9 +12,8 @@ class HaberdasherService(HaberdasherSync):
     def MakeHat(self, req: Size, ctx: ServiceContext) -> Hat:
         print("remaining_time: ", ctx.timeout_ms())
         if req.inches <= 0:
-            raise ConnecpyServerException(
-                code=Code.INVALID_ARGUMENT,
-                message="inches I can't make a hat that small!",
+            raise ConnecpyException(
+                Code.INVALID_ARGUMENT, "inches I can't make a hat that small!"
             )
         response = Hat(
             size=req.inches,

--- a/noextras/test/test_compression_default.py
+++ b/noextras/test/test_compression_default.py
@@ -1,6 +1,6 @@
 import pytest
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from example.haberdasher_connecpy import (
     Haberdasher,
     HaberdasherASGIApplication,
@@ -70,7 +70,7 @@ def test_invalid_compression_sync(compression: str):
             send_compression=compression,
             accept_compression=[compression] if compression else None,
         ) as client,
-        pytest.raises(ConnecpyServerException) as exc_info,
+        pytest.raises(ConnecpyException) as exc_info,
     ):
         client.MakeHat(request=Size(inches=10))
     assert exc_info.value.code == Code.UNAVAILABLE
@@ -92,7 +92,7 @@ async def test_invalid_compression_async(compression: str):
         send_compression=compression,
         accept_compression=[compression] if compression else None,
     ) as client:
-        with pytest.raises(ConnecpyServerException) as exc_info:
+        with pytest.raises(ConnecpyException) as exc_info:
             await client.MakeHat(request=Size(inches=10))
     assert exc_info.value.code == Code.UNAVAILABLE
     assert exc_info.value.message == f"Unsupported compression method: {compression}"

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -42,7 +42,7 @@ import httpx
 
 from connecpy.client import ConnecpyClient, ConnecpyClientSync, RequestHeaders
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from connecpy.server import ConnecpyASGIApplication, ConnecpyWSGIApplication, Endpoint, ServerInterceptor, ServiceContext
 
 {{- range .Imports }}
@@ -54,7 +54,7 @@ import {{.Name}} as {{.Alias}}
 
 class {{.Name}}(Protocol):{{- range .Methods }}
     async def {{.Name}}(self, req: {{.InputType}}, ctx: ServiceContext) -> {{.OutputType}}:
-        raise ConnecpyServerException(code=Code.UNIMPLEMENTED, message="Not implemented")
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 {{ end }}
 
 class {{.Name}}ASGIApplication(ConnecpyASGIApplication):
@@ -105,7 +105,7 @@ class {{.Name}}Client(ConnecpyClient):{{range .Methods}}
 {{range .Services}}
 class {{.Name}}Sync(Protocol):{{- range .Methods }}
     def {{.Name}}(self, req: {{.InputType}}, ctx: ServiceContext) -> {{.OutputType}}:
-        raise ConnecpyServerException(code=Code.UNIMPLEMENTED, message="Not implemented")
+        raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 {{- end }}
 
 

--- a/src/connecpy/_client_async.py
+++ b/src/connecpy/_client_async.py
@@ -10,7 +10,7 @@ from ._client_shared import RequestHeaders
 from ._codec import get_proto_binary_codec, get_proto_json_codec
 from ._protocol import ConnectWireError
 from .code import Code
-from .exceptions import ConnecpyServerException
+from .exceptions import ConnecpyException
 
 _RES = TypeVar("_RES", bound=Message)
 
@@ -143,22 +143,13 @@ class ConnecpyClient:
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
         except (httpx.TimeoutException, TimeoutError):
-            raise ConnecpyServerException(
-                code=Code.DEADLINE_EXCEEDED,
-                message="Request timed out",
-            )
-        except ConnecpyServerException:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except ConnecpyException:
             raise
         except CancelledError as e:
-            raise ConnecpyServerException(
-                code=Code.CANCELED,
-                message="Request was cancelled",
-            ) from e
+            raise ConnecpyException(Code.CANCELED, "Request was cancelled") from e
         except Exception as e:
-            raise ConnecpyServerException(
-                code=Code.UNAVAILABLE,
-                message=str(e),
-            )
+            raise ConnecpyException(Code.UNAVAILABLE, str(e))
 
 
 def _convert_connect_timeout(timeout_ms: Optional[int]) -> Timeout:

--- a/src/connecpy/_client_shared.py
+++ b/src/connecpy/_client_shared.py
@@ -14,7 +14,7 @@ from ._protocol import (
     codec_name_from_content_type,
 )
 from .code import Code
-from .exceptions import ConnecpyServerException
+from .exceptions import ConnecpyException
 
 # TODO: Embed package version correctly
 _DEFAULT_CONNECT_USER_AGENT = "connecpy/0.0.0"
@@ -89,9 +89,9 @@ def validate_response_content_encoding(
     if not encoding:
         return
     if encoding.lower() not in _compression.get_available_compressions():
-        raise ConnecpyServerException(
-            code=Code.INTERNAL,
-            message=f"unknown encoding '{encoding}'; accepted encodings are {', '.join(_compression.get_available_compressions())}",
+        raise ConnecpyException(
+            Code.INTERNAL,
+            f"unknown encoding '{encoding}'; accepted encodings are {', '.join(_compression.get_available_compressions())}",
         )
 
 
@@ -110,9 +110,9 @@ def validate_response_content_type(
         raise ConnectWireError.from_http_status(status_code).to_exception()
 
     if not response_content_type.startswith(CONNECT_UNARY_CONTENT_TYPE_PREFIX):
-        raise ConnecpyServerException(
-            code=Code.UNKNOWN,
-            message=f"invalid content-type: '{response_content_type}'; expecting '{CONNECT_UNARY_CONTENT_TYPE_PREFIX}{request_codec_name}'",
+        raise ConnecpyException(
+            Code.UNKNOWN,
+            f"invalid content-type: '{response_content_type}'; expecting '{CONNECT_UNARY_CONTENT_TYPE_PREFIX}{request_codec_name}'",
         )
 
     response_codec_name = codec_name_from_content_type(response_content_type)
@@ -129,9 +129,9 @@ def validate_response_content_type(
         # Both are JSON
         return
 
-    raise ConnecpyServerException(
-        code=Code.INTERNAL,
-        message=f"invalid content-type: '{response_content_type}'; expecting '{CONNECT_UNARY_CONTENT_TYPE_PREFIX}{request_codec_name}'",
+    raise ConnecpyException(
+        Code.INTERNAL,
+        f"invalid content-type: '{response_content_type}'; expecting '{CONNECT_UNARY_CONTENT_TYPE_PREFIX}{request_codec_name}'",
     )
 
 

--- a/src/connecpy/_client_sync.py
+++ b/src/connecpy/_client_sync.py
@@ -9,7 +9,7 @@ from ._client_shared import RequestHeaders
 from ._codec import get_proto_binary_codec, get_proto_json_codec
 from ._protocol import ConnectWireError
 from .code import Code
-from .exceptions import ConnecpyServerException
+from .exceptions import ConnecpyException
 
 _RES = TypeVar("_RES", bound=Message)
 
@@ -131,14 +131,11 @@ class ConnecpyClientSync:
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
         except httpx.TimeoutException:
-            raise ConnecpyServerException(
-                code=Code.DEADLINE_EXCEEDED,
-                message="Request timed out",
-            )
-        except ConnecpyServerException:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except ConnecpyException:
             raise
         except Exception as e:
-            raise ConnecpyServerException(code=Code.UNAVAILABLE, message=str(e))
+            raise ConnecpyException(Code.UNAVAILABLE, str(e))
 
 
 # Convert a timeout with connect semantics to a httpx.Timeout. Connect timeouts

--- a/src/connecpy/_server_async.py
+++ b/src/connecpy/_server_async.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Tuple
 from urllib.parse import parse_qs
 
-from . import _compression, _server_shared, exceptions
+from . import _compression, _server_shared
 from ._codec import Codec, get_codec
 from ._protocol import (
     CONNECT_UNARY_CONTENT_TYPE_PREFIX,
@@ -14,6 +14,7 @@ from ._protocol import (
 )
 from ._server_shared import ServiceContext
 from .code import Code
+from .exceptions import ConnecpyException
 
 if TYPE_CHECKING:
     # We don't use asgiref code so only import from it for type checking
@@ -147,9 +148,9 @@ class ConnecpyASGIApplication:
 
         # Validation
         if "message" not in params:
-            raise exceptions.ConnecpyServerException(
-                code=Code.INVALID_ARGUMENT,
-                message="'message' parameter is required for GET requests",
+            raise ConnecpyException(
+                Code.INVALID_ARGUMENT,
+                "'message' parameter is required for GET requests",
             )
 
         # Get and decode message
@@ -160,9 +161,8 @@ class ConnecpyASGIApplication:
             try:
                 message = base64.urlsafe_b64decode(message + "===")
             except Exception:
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INVALID_ARGUMENT,
-                    message="Invalid base64 encoding",
+                raise ConnecpyException(
+                    Code.INVALID_ARGUMENT, "Invalid base64 encoding"
                 )
         else:
             message = message.encode("utf-8")
@@ -171,18 +171,17 @@ class ConnecpyASGIApplication:
         codec_name = params.get("encoding", ("",))[0]
         codec = get_codec(codec_name)
         if not codec:
-            raise exceptions.ConnecpyServerException(
-                code=Code.UNIMPLEMENTED,
-                message=f"invalid message encoding: '{codec_name}'",
+            raise ConnecpyException(
+                Code.UNIMPLEMENTED, f"invalid message encoding: '{codec_name}'"
             )
 
         # Handle compression
         compression_name = params.get("compression", ["identity"])[0]
         compression = _compression.get_compression(compression_name)
         if not compression:
-            raise exceptions.ConnecpyServerException(
-                code=Code.UNIMPLEMENTED,
-                message=f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
+            raise ConnecpyException(
+                Code.UNIMPLEMENTED,
+                f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
             )
 
         # Decompress and decode message
@@ -216,9 +215,9 @@ class ConnecpyASGIApplication:
         req_body = await self._read_body(receive)
 
         if len(req_body) > self._max_receive_message_length:
-            raise exceptions.ConnecpyServerException(
-                code=Code.INVALID_ARGUMENT,
-                message=f"Request body exceeds maximum size of {self._max_receive_message_length} bytes",
+            raise ConnecpyException(
+                Code.INVALID_ARGUMENT,
+                f"Request body exceeds maximum size of {self._max_receive_message_length} bytes",
             )
 
         # Handle compression if specified
@@ -230,9 +229,9 @@ class ConnecpyASGIApplication:
         )
         compression = _compression.get_compression(compression_name)
         if not compression:
-            raise exceptions.ConnecpyServerException(
-                code=Code.UNIMPLEMENTED,
-                message=f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
+            raise ConnecpyException(
+                Code.UNIMPLEMENTED,
+                f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
             )
 
         if req_body:  # Don't decompress empty body
@@ -251,14 +250,14 @@ class ConnecpyASGIApplication:
                     if not message.get("more_body", False):
                         break
                 case "http.disconnect":
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.CANCELED,
-                        message="Client disconnected before request completion",
+                    raise ConnecpyException(
+                        Code.CANCELED,
+                        "Client disconnected before request completion",
                     )
                 case _:
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.UNKNOWN,
-                        message="Unexpected message type",
+                    raise ConnecpyException(
+                        Code.UNKNOWN,
+                        "Unexpected message type",
                     )
         return b"".join(chunks)
 

--- a/src/connecpy/_server_shared.py
+++ b/src/connecpy/_server_shared.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from .code import Code
-from .exceptions import ConnecpyServerException
+from .exceptions import ConnecpyException
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -52,9 +52,9 @@ class ServiceContext:
             "connect-protocol-version", ["1"]
         )[0]
         if connect_protocol_version != "1":
-            raise ConnecpyServerException(
-                code=Code.INVALID_ARGUMENT,
-                message=f"connect-protocol-version must be '1': got '{connect_protocol_version}'",
+            raise ConnecpyException(
+                Code.INVALID_ARGUMENT,
+                f"connect-protocol-version must be '1': got '{connect_protocol_version}'",
             )
         self._connect_protocol_version = connect_protocol_version
 

--- a/src/connecpy/_server_sync.py
+++ b/src/connecpy/_server_sync.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, List, Mapping, Optional
 from urllib.parse import parse_qs
 from wsgiref.types import StartResponse, WSGIEnvironment
 
-from . import _compression, _server_shared, exceptions
+from . import _compression, _server_shared
 from ._codec import Codec, get_codec
 from ._protocol import (
     CONNECT_UNARY_CONTENT_TYPE_PREFIX,
@@ -15,6 +15,7 @@ from ._protocol import (
 )
 from ._server_shared import ServiceContext
 from .code import Code
+from .exceptions import ConnecpyException
 
 
 def _normalize_wsgi_headers(environ: WSGIEnvironment) -> dict:
@@ -61,17 +62,15 @@ def validate_request_headers(headers: dict) -> tuple[str, str]:
     # Get content type
     content_type = headers.get("content-type", "application/json").lower()
     if content_type not in ["application/json", "application/proto"]:
-        raise exceptions.ConnecpyServerException(
-            code=Code.INVALID_ARGUMENT,
-            message=f"Unsupported Content-Type: {content_type}",
+        raise ConnecpyException(
+            Code.INVALID_ARGUMENT, f"Unsupported Content-Type: {content_type}"
         )
 
     # Get content encoding
     content_encoding = headers.get("content-encoding", "identity").lower()
     if content_encoding not in ["identity", "gzip", "br", "zstd"]:
-        raise exceptions.ConnecpyServerException(
-            code=Code.UNIMPLEMENTED,
-            message=f"Unsupported Content-Encoding: {content_encoding}",
+        raise ConnecpyException(
+            Code.UNIMPLEMENTED, f"Unsupported Content-Encoding: {content_encoding}"
         )
 
     return content_type, content_encoding
@@ -250,31 +249,30 @@ class ConnecpyWSGIApplication:
             if compression_name != "identity":
                 compression = _compression.get_compression(compression_name)
                 if not compression:
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.UNIMPLEMENTED,
-                        message=f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
+                    raise ConnecpyException(
+                        Code.UNIMPLEMENTED,
+                        f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
                     )
                 try:
                     req_body = compression.decompress(req_body)
                 except Exception as e:
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.INVALID_ARGUMENT,
-                        message=f"Failed to decompress request body: {str(e)}",
+                    raise ConnecpyException(
+                        Code.INVALID_ARGUMENT,
+                        f"Failed to decompress request body: {str(e)}",
                     )
 
             try:
                 return codec.decode(req_body, endpoint.input()), codec
             except Exception as e:
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INVALID_ARGUMENT,
-                    message=f"Failed to decode request body: {str(e)}",
+                raise ConnecpyException(
+                    Code.INVALID_ARGUMENT, f"Failed to decode request body: {str(e)}"
                 )
 
         except Exception as e:
-            if not isinstance(e, exceptions.ConnecpyServerException):
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INTERNAL,
-                    message=str(e),  # TODO
+            if not isinstance(e, ConnecpyException):
+                raise ConnecpyException(
+                    Code.INTERNAL,
+                    str(e),  # TODO
                 )
             raise
 
@@ -285,9 +283,9 @@ class ConnecpyWSGIApplication:
             params = parse_qs(query_string)
 
             if "message" not in params:
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INVALID_ARGUMENT,
-                    message="'message' parameter is required for GET requests",
+                raise ConnecpyException(
+                    Code.INVALID_ARGUMENT,
+                    "'message' parameter is required for GET requests",
                 )
 
             message = params["message"][0]
@@ -296,9 +294,8 @@ class ConnecpyWSGIApplication:
                 try:
                     message = base64.urlsafe_b64decode(message + "===")
                 except Exception as e:
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.INVALID_ARGUMENT,
-                        message=f"Invalid base64 encoding: {str(e)}",
+                    raise ConnecpyException(
+                        Code.INVALID_ARGUMENT, f"Invalid base64 encoding: {str(e)}"
                     )
             else:
                 message = message.encode("utf-8")
@@ -308,18 +305,17 @@ class ConnecpyWSGIApplication:
                 compression_name = params["compression"][0]
                 compression = _compression.get_compression(compression_name)
                 if not compression:
-                    raise exceptions.ConnecpyServerException(
-                        code=Code.UNIMPLEMENTED,
-                        message=f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
+                    raise ConnecpyException(
+                        Code.UNIMPLEMENTED,
+                        f"unknown compression: '{compression_name}': supported encodings are {', '.join(_compression.get_available_compressions())}",
                     )
                 message = compression.decompress(message)
 
             codec_name = params.get("encoding", ("",))[0]
             codec = get_codec(codec_name)
             if not codec:
-                raise exceptions.ConnecpyServerException(
-                    code=Code.UNIMPLEMENTED,
-                    message=f"invalid message encoding: '{codec_name}'",
+                raise ConnecpyException(
+                    Code.UNIMPLEMENTED, f"invalid message encoding: '{codec_name}'"
                 )
             # Handle GET request with proto decoder
             try:
@@ -327,17 +323,13 @@ class ConnecpyWSGIApplication:
                 request = codec.decode(message, endpoint.input())
                 return request, codec
             except Exception as e:
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INVALID_ARGUMENT,
-                    message=f"Failed to decode message: {str(e)}",
+                raise ConnecpyException(
+                    Code.INVALID_ARGUMENT, f"Failed to decode message: {str(e)}"
                 )
 
         except Exception as e:
-            if not isinstance(e, exceptions.ConnecpyServerException):
-                raise exceptions.ConnecpyServerException(
-                    code=Code.INTERNAL,
-                    message=str(e),
-                )
+            if not isinstance(e, ConnecpyException):
+                raise ConnecpyException(Code.INTERNAL, str(e))
             raise
 
     def _handle_error(

--- a/src/connecpy/exceptions.py
+++ b/src/connecpy/exceptions.py
@@ -1,14 +1,14 @@
-from typing import Sequence
+from typing import Iterable, Sequence
 
 from google.protobuf.any import Any, pack
 from google.protobuf.message import Message
 
 from .code import Code
 
-__all__ = ["ConnecpyServerException"]
+__all__ = ["ConnecpyException"]
 
 
-class ConnecpyServerException(Exception):
+class ConnecpyException(Exception):
     """
     Exception class for Connecpy server errors.
 
@@ -17,15 +17,15 @@ class ConnecpyServerException(Exception):
         message (str): The error message associated with the exception.
     """
 
-    def __init__(self, *, code, message, details: Sequence[Message] = ()):
+    def __init__(self, code: Code, message: str, details: Iterable[Message] = ()):
         """
-        Initializes a new instance of the ConnecpyServerException class.
+        Initializes a new instance of the ConnecpyException class.
 
         Args:
             code (int): The error code.
             message (str): The error message.
         """
-        super(ConnecpyServerException, self).__init__(message)
+        super(ConnecpyException, self).__init__(message)
         try:
             self._code = Code(code)
         except ValueError:

--- a/test/test_details.py
+++ b/test/test_details.py
@@ -9,7 +9,7 @@ from httpx import (
 )
 
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyServerException
+from connecpy.exceptions import ConnecpyException
 from example.haberdasher_connecpy import (
     Haberdasher,
     HaberdasherASGIApplication,
@@ -24,9 +24,9 @@ from example.haberdasher_pb2 import Size
 def test_details_sync():
     class DetailsHaberdasherSync(HaberdasherSync):
         def MakeHat(self, req, ctx):
-            raise ConnecpyServerException(
-                code=Code.RESOURCE_EXHAUSTED,
-                message="Resource exhausted",
+            raise ConnecpyException(
+                Code.RESOURCE_EXHAUSTED,
+                "Resource exhausted",
                 details=[
                     Struct(fields={"animal": Value(string_value="bear")}),
                     pack(Struct(fields={"color": Value(string_value="red")})),
@@ -38,7 +38,7 @@ def test_details_sync():
         HaberdasherClientSync(
             "http://localhost", session=Client(transport=WSGITransport(app=app))
         ) as client,
-        pytest.raises(ConnecpyServerException) as exc_info,
+        pytest.raises(ConnecpyException) as exc_info,
     ):
         client.MakeHat(request=Size(inches=10))
     assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
@@ -56,9 +56,9 @@ def test_details_sync():
 async def test_details_async():
     class DetailsHaberdasher(Haberdasher):
         async def MakeHat(self, req, ctx):
-            raise ConnecpyServerException(
-                code=Code.RESOURCE_EXHAUSTED,
-                message="Resource exhausted",
+            raise ConnecpyException(
+                Code.RESOURCE_EXHAUSTED,
+                "Resource exhausted",
                 details=[
                     Struct(fields={"animal": Value(string_value="bear")}),
                     pack(Struct(fields={"color": Value(string_value="red")})),
@@ -70,7 +70,7 @@ async def test_details_async():
     async with HaberdasherClient(
         "http://localhost", session=AsyncClient(transport=transport)
     ) as client:
-        with pytest.raises(ConnecpyServerException) as exc_info:
+        with pytest.raises(ConnecpyException) as exc_info:
             await client.MakeHat(request=Size(inches=10))
     assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
     assert exc_info.value.message == "Resource exhausted"

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -1,10 +1,11 @@
+import pytest
 from httpx import (
     ASGITransport,
     AsyncClient,
     Client,
     WSGITransport,
 )
-import pytest
+
 from example.haberdasher_connecpy import (
     Haberdasher,
     HaberdasherASGIApplication,


### PR DESCRIPTION
When cleaning up public API, I collapsed the two exceptions to `ConnecpyServerException`. But I realized it's better to consolidate on `ConnecpyException` - it matches `ConnectError` in the upstream libraries better, and is clearer it is used in client too, not just server.

Also allows positional arguments for the parameters, because the typical usage of `ConnecpyException(Code.FOO, "message")` is very readable without keywords