### PR TITLE
chore: add release workflow on tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version-file: "pyproject.toml"
+
+      - run: uv sync
+
+      - run: uv build
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,3 +24,5 @@ jobs:
       - run: uv build
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+            password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I can't verify this well so sorry if it has issues, but I think it should generally work. How about automating the release process?

https://github.com/pypa/gh-action-pypi-publish

If not done yet, it seems you would need to update the pypi settings to add github actions as a trusted publisher

https://docs.pypi.org/trusted-publishers/adding-a-publisher/