### PR TITLE
fix: resolve goreleaser dirty state error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           go-version-file: go.work
           cache-dependency-path: "**/go.mod"
 
-      - run: uv sync
+      - run: uv sync --frozen
 
       - run: uv build
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ protoc-gen-connecpy/protoc-gen-connecpy
 out/
 
 go.work.sum
+
+# GitHub Actions temporary files
+.github/.tmp/


### PR DESCRIPTION
## WHAT
This PR fixes  goreleaser "dirty state" error in release workflow.

## WHY
Probably, the latest release build was failing because uv sync updates uv.lock and .github/.tmp/ was created, causing goreleaser to detect uncommitted changes.
