### PR TITLE
test: add tests for half duplex bidi

### DIFF
--- a/conformance/test/config.yaml
+++ b/conformance/test/config.yaml
@@ -2,8 +2,9 @@ features:
   versions:
     - HTTP_VERSION_1
     - HTTP_VERSION_2
-  supports_trailers: false
+  supports_half_duplex_bidi_over_http1: true
   supports_message_receive_limit: false
+  supports_trailers: false
   protocols:
     - PROTOCOL_CONNECT
   codecs:
@@ -17,4 +18,5 @@ features:
   stream_types:
     - STREAM_TYPE_CLIENT_STREAM
     - STREAM_TYPE_SERVER_STREAM
+    - STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
     - STREAM_TYPE_UNARY

--- a/conformance/test/test_server.py
+++ b/conformance/test/test_server.py
@@ -13,6 +13,8 @@ _config_path = str(_current_dir / "config.yaml")
 _skipped_tests = [
     # TODO: Implement server side of streaming
     "--skip",
+    "**/bidi-stream/**",
+    "--skip",
     "**/client-stream/**",
     "--skip",
     "**/server-stream/**",


### PR DESCRIPTION
Unfortunately unless httpx adds support for full duplex bidi in https://github.com/encode/httpx/issues/1150, we can only support half duplex. 