### PR TITLE
chore: remove getattr and fix endpoint types

### DIFF
--- a/conformance/test/connectrpc/conformance/v1/service_connecpy.py
+++ b/conformance/test/connectrpc/conformance/v1/service_connecpy.py
@@ -17,6 +17,7 @@ from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
     Endpoint,
+    EndpointSync,
     ServerInterceptor,
     ServiceContext,
 )
@@ -83,7 +84,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="Unary",
-                    function=getattr(service, "Unary"),
+                    function=service.Unary,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
                     allowed_methods=("POST",),
@@ -94,7 +95,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="ServerStream",
-                    function=getattr(service, "ServerStream"),
+                    function=service.ServerStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
                     allowed_methods=("POST",),
@@ -105,7 +106,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="ClientStream",
-                    function=getattr(service, "ClientStream"),
+                    function=service.ClientStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
                     allowed_methods=("POST",),
@@ -116,7 +117,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="BidiStream",
-                    function=getattr(service, "BidiStream"),
+                    function=service.BidiStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
                     allowed_methods=("POST",),
@@ -127,7 +128,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="Unimplemented",
-                    function=getattr(service, "Unimplemented"),
+                    function=service.Unimplemented,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
                     allowed_methods=("POST",),
@@ -138,7 +139,7 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="ConformanceService",
                     name="IdempotentUnary",
-                    function=getattr(service, "IdempotentUnary"),
+                    function=service.IdempotentUnary,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
                     allowed_methods=("GET", "POST"),
@@ -309,68 +310,68 @@ class ConformanceServiceWSGIApplication(ConnecpyWSGIApplication):
     def __init__(self, service: ConformanceServiceSync):
         super().__init__(
             endpoints={
-                "/connectrpc.conformance.v1.ConformanceService/Unary": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/Unary": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
                 ](
                     service_name="ConformanceService",
                     name="Unary",
-                    function=getattr(service, "Unary"),
+                    function=service.Unary,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
                     allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ServerStream": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/ServerStream": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
                 ](
                     service_name="ConformanceService",
                     name="ServerStream",
-                    function=getattr(service, "ServerStream"),
+                    function=service.ServerStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
                     allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ClientStream": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/ClientStream": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
                 ](
                     service_name="ConformanceService",
                     name="ClientStream",
-                    function=getattr(service, "ClientStream"),
+                    function=service.ClientStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
                     allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/BidiStream": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/BidiStream": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
                 ](
                     service_name="ConformanceService",
                     name="BidiStream",
-                    function=getattr(service, "BidiStream"),
+                    function=service.BidiStream,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
                     allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
                 ](
                     service_name="ConformanceService",
                     name="Unimplemented",
-                    function=getattr(service, "Unimplemented"),
+                    function=service.Unimplemented,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
                     allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": Endpoint[
+                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": EndpointSync[
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
                     connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
                 ](
                     service_name="ConformanceService",
                     name="IdempotentUnary",
-                    function=getattr(service, "IdempotentUnary"),
+                    function=service.IdempotentUnary,
                     input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
                     output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
                     allowed_methods=("GET", "POST"),

--- a/example/example/haberdasher_connecpy.py
+++ b/example/example/haberdasher_connecpy.py
@@ -15,6 +15,7 @@ from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
     Endpoint,
+    EndpointSync,
     ServerInterceptor,
     ServiceContext,
 )
@@ -49,7 +50,7 @@ class HaberdasherASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="Haberdasher",
                     name="MakeHat",
-                    function=getattr(service, "MakeHat"),
+                    function=service.MakeHat,
                     input=example_dot_haberdasher__pb2.Size,
                     output=example_dot_haberdasher__pb2.Hat,
                     allowed_methods=("GET", "POST"),
@@ -60,7 +61,7 @@ class HaberdasherASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="Haberdasher",
                     name="DoNothing",
-                    function=getattr(service, "DoNothing"),
+                    function=service.DoNothing,
                     input=google_dot_protobuf_dot_empty__pb2.Empty,
                     output=google_dot_protobuf_dot_empty__pb2.Empty,
                     allowed_methods=("POST",),
@@ -127,23 +128,23 @@ class HaberdasherWSGIApplication(ConnecpyWSGIApplication):
     def __init__(self, service: HaberdasherSync):
         super().__init__(
             endpoints={
-                "/i2y.connecpy.example.Haberdasher/MakeHat": Endpoint[
+                "/i2y.connecpy.example.Haberdasher/MakeHat": EndpointSync[
                     example_dot_haberdasher__pb2.Size, example_dot_haberdasher__pb2.Hat
                 ](
                     service_name="Haberdasher",
                     name="MakeHat",
-                    function=getattr(service, "MakeHat"),
+                    function=service.MakeHat,
                     input=example_dot_haberdasher__pb2.Size,
                     output=example_dot_haberdasher__pb2.Hat,
                     allowed_methods=("GET", "POST"),
                 ),
-                "/i2y.connecpy.example.Haberdasher/DoNothing": Endpoint[
+                "/i2y.connecpy.example.Haberdasher/DoNothing": EndpointSync[
                     google_dot_protobuf_dot_empty__pb2.Empty,
                     google_dot_protobuf_dot_empty__pb2.Empty,
                 ](
                     service_name="Haberdasher",
                     name="DoNothing",
-                    function=getattr(service, "DoNothing"),
+                    function=service.DoNothing,
                     input=google_dot_protobuf_dot_empty__pb2.Empty,
                     output=google_dot_protobuf_dot_empty__pb2.Empty,
                     allowed_methods=("POST",),

--- a/example/example/haberdasher_edition_2023_connecpy.py
+++ b/example/example/haberdasher_edition_2023_connecpy.py
@@ -15,6 +15,7 @@ from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
     Endpoint,
+    EndpointSync,
     ServerInterceptor,
     ServiceContext,
 )
@@ -44,7 +45,7 @@ class HaberdasherASGIApplication(ConnecpyASGIApplication):
                 ](
                     service_name="Haberdasher",
                     name="MakeHat",
-                    function=getattr(service, "MakeHat"),
+                    function=service.MakeHat,
                     input=example_dot_haberdasher__edition__2023__pb2.Size,
                     output=example_dot_haberdasher__edition__2023__pb2.Hat,
                     allowed_methods=("GET", "POST"),
@@ -90,13 +91,13 @@ class HaberdasherWSGIApplication(ConnecpyWSGIApplication):
     def __init__(self, service: HaberdasherSync):
         super().__init__(
             endpoints={
-                "/i2y.connecpy.example2023.Haberdasher/MakeHat": Endpoint[
+                "/i2y.connecpy.example2023.Haberdasher/MakeHat": EndpointSync[
                     example_dot_haberdasher__edition__2023__pb2.Size,
                     example_dot_haberdasher__edition__2023__pb2.Hat,
                 ](
                     service_name="Haberdasher",
                     name="MakeHat",
-                    function=getattr(service, "MakeHat"),
+                    function=service.MakeHat,
                     input=example_dot_haberdasher__edition__2023__pb2.Size,
                     output=example_dot_haberdasher__edition__2023__pb2.Hat,
                     allowed_methods=("GET", "POST"),

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -45,7 +45,7 @@ from connecpy.client import ConnecpyClient, ConnecpyClientSync, ResponseStream, 
 from connecpy.code import Code
 from connecpy.exceptions import ConnecpyException
 from connecpy.headers import Headers
-from connecpy.server import ConnecpyASGIApplication, ConnecpyWSGIApplication, Endpoint, ServerInterceptor, ServiceContext
+from connecpy.server import ConnecpyASGIApplication, ConnecpyWSGIApplication, Endpoint, EndpointSync, ServerInterceptor, ServiceContext
 
 {{- range .Imports }}
 import {{.Name}} as {{.Alias}}
@@ -66,7 +66,7 @@ class {{.Name}}ASGIApplication(ConnecpyASGIApplication):
                 "/{{.Package}}.{{.ServiceName}}/{{.Name}}": Endpoint[{{.InputType}}, {{.OutputType}}](
                     service_name="{{.ServiceName}}",
                     name="{{.Name}}",
-                    function=getattr(service, "{{.Name}}"),
+                    function=service.{{.Name}},
                     input={{.InputType}},
                     output={{.OutputType}},
                     allowed_methods={{if .NoSideEffects}}("GET", "POST"){{else}}("POST",){{end}},
@@ -126,10 +126,10 @@ class {{.Name}}WSGIApplication(ConnecpyWSGIApplication):
     def __init__(self, service: {{.Name}}Sync):
         super().__init__(
             endpoints={ {{- range .Methods }}
-                "/{{.Package}}.{{.ServiceName}}/{{.Name}}": Endpoint[{{.InputType}}, {{.OutputType}}](
+                "/{{.Package}}.{{.ServiceName}}/{{.Name}}": EndpointSync[{{.InputType}}, {{.OutputType}}](
                     service_name="{{.ServiceName}}",
                     name="{{.Name}}",
-                    function=getattr(service, "{{.Name}}"),
+                    function=service.{{.Name}},
                     input={{.InputType}},
                     output={{.OutputType}},
                     allowed_methods={{if .NoSideEffects}}("GET", "POST"){{else}}("POST",){{end}},

--- a/src/connecpy/_server_sync.py
+++ b/src/connecpy/_server_sync.py
@@ -132,7 +132,7 @@ class ConnecpyWSGIApplication(ABC):
     def path(self) -> str:
         raise NotImplementedError()
 
-    def __init__(self, *, endpoints: Mapping[str, _server_shared.Endpoint]):
+    def __init__(self, *, endpoints: Mapping[str, _server_shared.EndpointSync]):
         """Initialize the WSGI application."""
         super().__init__()
         self._endpoints = endpoints
@@ -216,7 +216,7 @@ class ConnecpyWSGIApplication(ABC):
     def _handle_post_request(
         self,
         environ: WSGIEnvironment,
-        endpoint: _server_shared.Endpoint,
+        endpoint: _server_shared.EndpointSync,
         ctx: _server_shared.ServiceContext,
         request_headers: Headers,
     ) -> tuple[Any, Codec]:

--- a/src/connecpy/server.py
+++ b/src/connecpy/server.py
@@ -1,11 +1,12 @@
 from ._server_async import ConnecpyASGIApplication
-from ._server_shared import Endpoint, ServerInterceptor, ServiceContext
+from ._server_shared import Endpoint, EndpointSync, ServerInterceptor, ServiceContext
 from ._server_sync import ConnecpyWSGIApplication
 
 __all__ = [
     "ConnecpyASGIApplication",
     "ConnecpyWSGIApplication",
     "Endpoint",
+    "EndpointSync",
     "ServerInterceptor",
     "ServiceContext",
 ]


### PR DESCRIPTION
I randomly noticed `getattr` suppressing type checking of the generated code. I removed it and fixed the typing by defining a separate `EndpointSync`