### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/i2y/connecpy/security/code-scanning/1](https://github.com/i2y/connecpy/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs unless overridden. Since the workflow only checks out code and runs tests/lints, it does not appear to require write access to repository contents, issues, or pull requests. The minimal recommended permission is `contents: read`, which allows the workflow to read repository contents but not modify them. This change should be made at the top level of `.github/workflows/ci.yaml`, immediately after the `name:` field and before the `on:` field or after the `on:` field, as per GitHub Actions YAML conventions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
