### PR TITLE
test: enable client TLS conformance tests

### DIFF
--- a/conformance/test/client.py
+++ b/conformance/test/client.py
@@ -2,7 +2,7 @@ import argparse
 import asyncio
 import ssl
 import time
-from tempfile import TemporaryFile
+from tempfile import NamedTemporaryFile
 from typing import AsyncIterator, Iterator, Literal, TypeVar
 
 import httpx
@@ -133,7 +133,10 @@ async def _run_test(
                     cadata=test_request.server_tls_cert.decode(),
                 )
                 if test_request.HasField("client_tls_creds"):
-                    with TemporaryFile() as cert_file, TemporaryFile() as key_file:
+                    with (
+                        NamedTemporaryFile(delete_on_close=False) as cert_file,
+                        NamedTemporaryFile(delete_on_close=False) as key_file,
+                    ):
                         cert_file.write(test_request.client_tls_creds.cert)
                         cert_file.close()
                         key_file.write(test_request.client_tls_creds.key)

--- a/conformance/test/config.yaml
+++ b/conformance/test/config.yaml
@@ -2,9 +2,6 @@ features:
   versions:
     - HTTP_VERSION_1
     - HTTP_VERSION_2
-  supports_half_duplex_bidi_over_http1: true
-  supports_message_receive_limit: false
-  supports_trailers: false
   protocols:
     - PROTOCOL_CONNECT
   codecs:
@@ -21,3 +18,10 @@ features:
     - STREAM_TYPE_SERVER_STREAM
     - STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
     - STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+  supports_h2c: true
+  supports_tls: true
+  supports_tls_client_certs: true
+  supports_trailers: false
+  supports_half_duplex_bidi_over_http1: true
+  supports_connect_get: true
+  supports_message_receive_limit: false

--- a/conformance/test/server.py
+++ b/conformance/test/server.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import signal
 from contextlib import ExitStack
+from ssl import VerifyMode
 from tempfile import NamedTemporaryFile
 from typing import AsyncIterator, Literal, TypeVar
 
@@ -295,6 +296,14 @@ async def serve(
         key_file.close()
         conf.certfile = cert_file.name
         conf.keyfile = key_file.name
+        if request.client_tls_cert:
+            ca_cert_file = cleanup.enter_context(
+                NamedTemporaryFile(delete_on_close=False)
+            )
+            ca_cert_file.write(request.client_tls_cert)
+            ca_cert_file.close()
+            conf.ca_certs = ca_cert_file.name
+            conf.verify_mode = VerifyMode.CERT_REQUIRED
 
     conf._log = PortCapturingLogger(conf)
 


### PR DESCRIPTION
Also explicitly sets config for fields that are same as default to make coverage more obvious