### PR TITLE
feat: rework method invocation and interceptors

### DIFF
--- a/conformance/test/connectrpc/conformance/v1/service_connecpy.py
+++ b/conformance/test/connectrpc/conformance/v1/service_connecpy.py
@@ -13,12 +13,13 @@ from connecpy.client import (
 from connecpy.code import Code
 from connecpy.exceptions import ConnecpyException
 from connecpy.headers import Headers
+from connecpy.interceptor import Interceptor, InterceptorSync
+from connecpy.method import IdempotencyLevel, MethodInfo
 from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
     Endpoint,
     EndpointSync,
-    ServerInterceptor,
     ServiceContext,
 )
 import connectrpc.conformance.v1.service_pb2 as connectrpc_dot_conformance_dot_v1_dot_service__pb2
@@ -81,73 +82,70 @@ class ConformanceServiceASGIApplication(ConnecpyASGIApplication):
         self,
         service: ConformanceService,
         *,
-        interceptors: Iterable[ServerInterceptor] = (),
+        interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
     ):
         super().__init__(
             endpoints={
-                "/connectrpc.conformance.v1.ConformanceService/Unary": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="Unary",
+                "/connectrpc.conformance.v1.ConformanceService/Unary": Endpoint.unary(
+                    method=MethodInfo(
+                        name="Unary",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.Unary,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
-                    allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ServerStream": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
-                ].response_stream(
-                    service_name="ConformanceService",
-                    name="ServerStream",
+                "/connectrpc.conformance.v1.ConformanceService/ServerStream": Endpoint.server_stream(
+                    method=MethodInfo(
+                        name="ServerStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.ServerStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ClientStream": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
-                ].request_stream(
-                    service_name="ConformanceService",
-                    name="ClientStream",
+                "/connectrpc.conformance.v1.ConformanceService/ClientStream": Endpoint.client_stream(
+                    method=MethodInfo(
+                        name="ClientStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.ClientStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/BidiStream": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
-                ].bidi_stream(
-                    service_name="ConformanceService",
-                    name="BidiStream",
+                "/connectrpc.conformance.v1.ConformanceService/BidiStream": Endpoint.bidi_stream(
+                    method=MethodInfo(
+                        name="BidiStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.BidiStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="Unimplemented",
+                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": Endpoint.unary(
+                    method=MethodInfo(
+                        name="Unimplemented",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.Unimplemented,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
-                    allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": Endpoint[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="IdempotentUnary",
+                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": Endpoint.unary(
+                    method=MethodInfo(
+                        name="IdempotentUnary",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
+                        idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
+                    ),
                     function=service.IdempotentUnary,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
-                    allowed_methods=("GET", "POST"),
                 ),
             },
             interceptors=interceptors,
@@ -321,74 +319,75 @@ class ConformanceServiceSync(Protocol):
 
 class ConformanceServiceWSGIApplication(ConnecpyWSGIApplication):
     def __init__(
-        self, service: ConformanceServiceSync, read_max_bytes: int | None = None
+        self,
+        service: ConformanceServiceSync,
+        interceptors: Iterable[InterceptorSync] = (),
+        read_max_bytes: int | None = None,
     ):
         super().__init__(
             endpoints={
-                "/connectrpc.conformance.v1.ConformanceService/Unary": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="Unary",
+                "/connectrpc.conformance.v1.ConformanceService/Unary": EndpointSync.unary(
+                    method=MethodInfo(
+                        name="Unary",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.Unary,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse,
-                    allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ServerStream": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
-                ].response_stream(
-                    service_name="ConformanceService",
-                    name="ServerStream",
+                "/connectrpc.conformance.v1.ConformanceService/ServerStream": EndpointSync.server_stream(
+                    method=MethodInfo(
+                        name="ServerStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.ServerStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/ClientStream": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
-                ].request_stream(
-                    service_name="ConformanceService",
-                    name="ClientStream",
+                "/connectrpc.conformance.v1.ConformanceService/ClientStream": EndpointSync.client_stream(
+                    method=MethodInfo(
+                        name="ClientStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.ClientStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/BidiStream": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
-                ].bidi_stream(
-                    service_name="ConformanceService",
-                    name="BidiStream",
+                "/connectrpc.conformance.v1.ConformanceService/BidiStream": EndpointSync.bidi_stream(
+                    method=MethodInfo(
+                        name="BidiStream",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.BidiStream,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamResponse,
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="Unimplemented",
+                "/connectrpc.conformance.v1.ConformanceService/Unimplemented": EndpointSync.unary(
+                    method=MethodInfo(
+                        name="Unimplemented",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
+                        idempotency_level=IdempotencyLevel.UNKNOWN,
+                    ),
                     function=service.Unimplemented,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse,
-                    allowed_methods=("POST",),
                 ),
-                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": EndpointSync[
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
-                    connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
-                ].unary(
-                    service_name="ConformanceService",
-                    name="IdempotentUnary",
+                "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary": EndpointSync.unary(
+                    method=MethodInfo(
+                        name="IdempotentUnary",
+                        service_name="ConformanceService",
+                        input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
+                        output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
+                        idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
+                    ),
                     function=service.IdempotentUnary,
-                    input=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
-                    output=connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse,
-                    allowed_methods=("GET", "POST"),
                 ),
             },
+            interceptors=interceptors,
             read_max_bytes=read_max_bytes,
         )
 

--- a/example/example/haberdasher_edition_2023_connecpy.py
+++ b/example/example/haberdasher_edition_2023_connecpy.py
@@ -11,12 +11,13 @@ from connecpy.client import (
 from connecpy.code import Code
 from connecpy.exceptions import ConnecpyException
 from connecpy.headers import Headers
+from connecpy.interceptor import Interceptor, InterceptorSync
+from connecpy.method import IdempotencyLevel, MethodInfo
 from connecpy.server import (
     ConnecpyASGIApplication,
     ConnecpyWSGIApplication,
     Endpoint,
     EndpointSync,
-    ServerInterceptor,
     ServiceContext,
 )
 import example.haberdasher_edition_2023_pb2 as example_dot_haberdasher__edition__2023__pb2
@@ -34,21 +35,20 @@ class HaberdasherASGIApplication(ConnecpyASGIApplication):
         self,
         service: Haberdasher,
         *,
-        interceptors: Iterable[ServerInterceptor] = (),
+        interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
     ):
         super().__init__(
             endpoints={
-                "/i2y.connecpy.example2023.Haberdasher/MakeHat": Endpoint[
-                    example_dot_haberdasher__edition__2023__pb2.Size,
-                    example_dot_haberdasher__edition__2023__pb2.Hat,
-                ].unary(
-                    service_name="Haberdasher",
-                    name="MakeHat",
+                "/i2y.connecpy.example2023.Haberdasher/MakeHat": Endpoint.unary(
+                    method=MethodInfo(
+                        name="MakeHat",
+                        service_name="Haberdasher",
+                        input=example_dot_haberdasher__edition__2023__pb2.Size,
+                        output=example_dot_haberdasher__edition__2023__pb2.Hat,
+                        idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
+                    ),
                     function=service.MakeHat,
-                    input=example_dot_haberdasher__edition__2023__pb2.Size,
-                    output=example_dot_haberdasher__edition__2023__pb2.Hat,
-                    allowed_methods=("GET", "POST"),
                 ),
             },
             interceptors=interceptors,
@@ -88,21 +88,26 @@ class HaberdasherSync(Protocol):
 
 
 class HaberdasherWSGIApplication(ConnecpyWSGIApplication):
-    def __init__(self, service: HaberdasherSync, read_max_bytes: int | None = None):
+    def __init__(
+        self,
+        service: HaberdasherSync,
+        interceptors: Iterable[InterceptorSync] = (),
+        read_max_bytes: int | None = None,
+    ):
         super().__init__(
             endpoints={
-                "/i2y.connecpy.example2023.Haberdasher/MakeHat": EndpointSync[
-                    example_dot_haberdasher__edition__2023__pb2.Size,
-                    example_dot_haberdasher__edition__2023__pb2.Hat,
-                ].unary(
-                    service_name="Haberdasher",
-                    name="MakeHat",
+                "/i2y.connecpy.example2023.Haberdasher/MakeHat": EndpointSync.unary(
+                    method=MethodInfo(
+                        name="MakeHat",
+                        service_name="Haberdasher",
+                        input=example_dot_haberdasher__edition__2023__pb2.Size,
+                        output=example_dot_haberdasher__edition__2023__pb2.Hat,
+                        idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
+                    ),
                     function=service.MakeHat,
-                    input=example_dot_haberdasher__edition__2023__pb2.Size,
-                    output=example_dot_haberdasher__edition__2023__pb2.Hat,
-                    allowed_methods=("GET", "POST"),
                 ),
             },
+            interceptors=interceptors,
             read_max_bytes=read_max_bytes,
         )
 

--- a/example/example/server.py
+++ b/example/example/server.py
@@ -1,24 +1,26 @@
-from typing import Any, Callable
+from typing import Awaitable, Callable, TypeVar
 
-from connecpy.server import ServiceContext, ServerInterceptor
+from connecpy.server import ServiceContext
 
 from . import haberdasher_connecpy
 from .service import HaberdasherService
 
+T = TypeVar("T")
+U = TypeVar("U")
 
-class MyInterceptor(ServerInterceptor):
+
+class MyInterceptor:
     def __init__(self, msg):
         self._msg = msg
 
-    async def intercept(
+    async def intercept_unary(
         self,
-        method: Callable,
-        request: Any,
+        next: Callable[[T, ServiceContext], Awaitable[U]],
+        request: T,
         ctx: ServiceContext,
-        method_name: str,
-    ) -> Any:
-        print("intercepting " + method_name + " with " + self._msg)
-        return await method(request, ctx)
+    ) -> U:
+        print(f"intercepting {ctx.method().name} with {self._msg}")
+        return await next(request, ctx)
 
 
 my_interceptor_a = MyInterceptor("A")

--- a/example/proto/example/haberdasher.proto
+++ b/example/proto/example/haberdasher.proto
@@ -34,6 +34,10 @@ service Haberdasher {
   rpc MakeHat(Size) returns (Hat) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
+
+  // MakeFlexibleHats produces a single hat adhering to many sizes.
+  rpc MakeFlexibleHat(stream Size) returns (Hat) {}
+
   // MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
   rpc MakeSimilarHats(Size) returns (stream Hat) {
     option idempotency_level = NO_SIDE_EFFECTS;

--- a/src/connecpy/_codec.py
+++ b/src/connecpy/_codec.py
@@ -1,4 +1,4 @@
-from typing import Any, ByteString, Optional, Protocol
+from typing import Any, ByteString, Optional, Protocol, TypeVar
 
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.json_format import Parse as MessageFromJson
@@ -11,6 +11,9 @@ CODEC_NAME_JSON = "json"
 CODEC_NAME_JSON_CHARSET_UTF8 = "json; charset=utf-8"
 
 
+T = TypeVar("T")
+
+
 class Codec(Protocol):
     def name(self) -> str:
         """Returns the name of the codec."""
@@ -20,7 +23,7 @@ class Codec(Protocol):
         """Marshals the given message."""
         ...
 
-    def decode(self, data: ByteString, message: Any) -> Any:
+    def decode(self, data: ByteString, message: T) -> T:
         """Unmarshals the given message."""
         ...
 
@@ -36,7 +39,7 @@ class ProtoBinaryCodec(Codec):
             raise TypeError("Expected a protobuf Message instance")
         return message.SerializeToString()
 
-    def decode(self, data: ByteString, message: Any) -> Any:
+    def decode(self, data: ByteString, message: T) -> T:
         if not isinstance(message, Message):
             raise TypeError("Expected a protobuf Message instance")
         message.ParseFromString(data)  # pyright: ignore[reportArgumentType] - type is incorrect
@@ -54,7 +57,7 @@ class ProtoJSONCodec(Codec):
             raise TypeError("Expected a protobuf Message instance")
         return MessageToJson(message).encode()
 
-    def decode(self, data: ByteString, message: Any) -> Any:
+    def decode(self, data: ByteString, message: T) -> T:
         if not isinstance(message, Message):
             raise TypeError("Expected a protobuf Message instance")
         MessageFromJson(data, message)  # pyright: ignore[reportArgumentType] - type is incorrect

--- a/src/connecpy/_interceptor_async.py
+++ b/src/connecpy/_interceptor_async.py
@@ -1,0 +1,150 @@
+from typing import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generic,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
+
+from ._server_shared import ServiceContext
+
+REQ = TypeVar("REQ")
+RES = TypeVar("RES")
+T = TypeVar("T")
+
+
+@runtime_checkable
+class UnaryInterceptor(Protocol):
+    async def intercept_unary(
+        self,
+        next: Callable[[REQ, ServiceContext], Awaitable[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> RES:
+        """Intercepts a unary RPC."""
+        ...
+
+
+@runtime_checkable
+class ClientStreamInterceptor(Protocol):
+    async def intercept_client_stream(
+        self,
+        next: Callable[[AsyncIterator[REQ], ServiceContext], Awaitable[RES]],
+        request: AsyncIterator[REQ],
+        ctx: ServiceContext,
+    ) -> RES:
+        """Intercepts a client-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class ServerStreamInterceptor(Protocol):
+    def intercept_server_stream(
+        self,
+        next: Callable[[REQ, ServiceContext], AsyncIterator[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> AsyncIterator[RES]:
+        """Intercepts a server-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class BidiStreamInterceptor(Protocol):
+    def intercept_bidi_stream(
+        self,
+        next: Callable[[AsyncIterator[REQ], ServiceContext], AsyncIterator[RES]],
+        request: AsyncIterator[REQ],
+        ctx: ServiceContext,
+    ) -> AsyncIterator[RES]:
+        """Intercepts a bidirectional-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class MetadataInterceptor(Protocol[T]):
+    """An interceptor that can be applied to any type of method, only having
+    access to metadata such as headers and trailers.
+
+    To access request and response bodies of a method, instead use an interceptor
+    corresponding to the type of method such as UnaryInterceptor.
+    """
+
+    async def on_start(self, ctx: ServiceContext) -> T:
+        """Called when the RPC starts. The return value will be passed to on_end as-is.
+        For example, if measuring RPC invocation time, on_start may return the current
+        time.
+        """
+        ...
+
+    async def on_end(self, token: T, ctx: ServiceContext) -> None:
+        """Called when the RPC ends."""
+        ...
+
+
+Interceptor = (
+    UnaryInterceptor
+    | ClientStreamInterceptor
+    | ServerStreamInterceptor
+    | BidiStreamInterceptor
+    | MetadataInterceptor
+)
+
+
+class MetadataInterceptorInvoker(Generic[T]):
+    _delegate: MetadataInterceptor[T]
+
+    def __init__(self, delegate: MetadataInterceptor[T]) -> None:
+        self._delegate = delegate
+
+    async def intercept_unary(
+        self,
+        next: Callable[[REQ, ServiceContext], Awaitable[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> RES:
+        token = await self._delegate.on_start(ctx)
+        try:
+            return await next(request, ctx)
+        finally:
+            await self._delegate.on_end(token, ctx)
+
+    async def intercept_client_stream(
+        self,
+        next: Callable[[AsyncIterator[REQ], ServiceContext], Awaitable[RES]],
+        request: AsyncIterator[REQ],
+        ctx: ServiceContext,
+    ) -> RES:
+        token = await self._delegate.on_start(ctx)
+        try:
+            return await next(request, ctx)
+        finally:
+            await self._delegate.on_end(token, ctx)
+
+    async def intercept_server_stream(
+        self,
+        next: Callable[[REQ, ServiceContext], AsyncIterator[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> AsyncIterator[RES]:
+        token = await self._delegate.on_start(ctx)
+        try:
+            async for response in next(request, ctx):
+                yield response
+        finally:
+            await self._delegate.on_end(token, ctx)
+
+    async def intercept_bidi_stream(
+        self,
+        next: Callable[[AsyncIterator[REQ], ServiceContext], AsyncIterator[RES]],
+        request: AsyncIterator[REQ],
+        ctx: ServiceContext,
+    ) -> AsyncIterator[RES]:
+        token = await self._delegate.on_start(ctx)
+        try:
+            async for response in next(request, ctx):
+                yield response
+        finally:
+            await self._delegate.on_end(token, ctx)

--- a/src/connecpy/_interceptor_sync.py
+++ b/src/connecpy/_interceptor_sync.py
@@ -1,0 +1,147 @@
+from typing import (
+    Callable,
+    Generic,
+    Iterator,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
+
+from ._server_shared import ServiceContext
+
+REQ = TypeVar("REQ")
+RES = TypeVar("RES")
+T = TypeVar("T")
+
+
+@runtime_checkable
+class UnaryInterceptorSync(Protocol):
+    def intercept_unary_sync(
+        self,
+        next: Callable[[REQ, ServiceContext], RES],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> RES:
+        """Intercepts a unary RPC."""
+        ...
+
+
+@runtime_checkable
+class ClientStreamInterceptorSync(Protocol):
+    def intercept_client_stream_sync(
+        self,
+        next: Callable[[Iterator[REQ], ServiceContext], RES],
+        request: Iterator[REQ],
+        ctx: ServiceContext,
+    ) -> RES:
+        """Intercepts a client-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class ServerStreamInterceptorSync(Protocol):
+    def intercept_server_stream_sync(
+        self,
+        next: Callable[[REQ, ServiceContext], Iterator[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> Iterator[RES]:
+        """Intercepts a server-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class BidiStreamInterceptorSync(Protocol):
+    def intercept_bidi_stream_sync(
+        self,
+        next: Callable[[Iterator[REQ], ServiceContext], Iterator[RES]],
+        request: Iterator[REQ],
+        ctx: ServiceContext,
+    ) -> Iterator[RES]:
+        """Intercepts a bidirectional-streaming RPC."""
+        ...
+
+
+@runtime_checkable
+class MetadataInterceptorSync(Protocol[T]):
+    """An interceptor that can be applied to any type of method, only having
+    access to metadata such as headers and trailers.
+
+    To access request and response bodies of a method, instead use an interceptor
+    corresponding to the type of method such as UnaryInterceptor.
+    """
+
+    def on_start_sync(self, ctx: ServiceContext) -> T:
+        """Called when the RPC starts. The return value will be passed to on_end as-is.
+        For example, if measuring RPC invocation time, on_start may return the current
+        time.
+        """
+        ...
+
+    def on_end_sync(self, token: T, ctx: ServiceContext) -> None:
+        """Called when the RPC ends."""
+        ...
+
+
+InterceptorSync = (
+    UnaryInterceptorSync
+    | ClientStreamInterceptorSync
+    | ServerStreamInterceptorSync
+    | BidiStreamInterceptorSync
+    | MetadataInterceptorSync
+)
+
+
+class MetadataInterceptorInvokerSync(Generic[T]):
+    _delegate: MetadataInterceptorSync[T]
+
+    def __init__(self, delegate: MetadataInterceptorSync[T]) -> None:
+        self._delegate = delegate
+
+    def intercept_unary_sync(
+        self,
+        next: Callable[[REQ, ServiceContext], RES],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> RES:
+        token = self._delegate.on_start_sync(ctx)
+        try:
+            return next(request, ctx)
+        finally:
+            self._delegate.on_end_sync(token, ctx)
+
+    def intercept_client_stream_sync(
+        self,
+        next: Callable[[Iterator[REQ], ServiceContext], RES],
+        request: Iterator[REQ],
+        ctx: ServiceContext,
+    ) -> RES:
+        token = self._delegate.on_start_sync(ctx)
+        try:
+            return next(request, ctx)
+        finally:
+            self._delegate.on_end_sync(token, ctx)
+
+    def intercept_server_stream_sync(
+        self,
+        next: Callable[[REQ, ServiceContext], Iterator[RES]],
+        request: REQ,
+        ctx: ServiceContext,
+    ) -> Iterator[RES]:
+        token = self._delegate.on_start_sync(ctx)
+        try:
+            yield from next(request, ctx)
+        finally:
+            self._delegate.on_end_sync(token, ctx)
+
+    def intercept_bidi_stream_sync(
+        self,
+        next: Callable[[Iterator[REQ], ServiceContext], Iterator[RES]],
+        request: Iterator[REQ],
+        ctx: ServiceContext,
+    ) -> Iterator[RES]:
+        token = self._delegate.on_start_sync(ctx)
+        try:
+            yield from next(request, ctx)
+        finally:
+            self._delegate.on_end_sync(token, ctx)

--- a/src/connecpy/interceptor.py
+++ b/src/connecpy/interceptor.py
@@ -1,0 +1,31 @@
+from ._interceptor_async import (
+    BidiStreamInterceptor,
+    ClientStreamInterceptor,
+    Interceptor,
+    MetadataInterceptor,
+    ServerStreamInterceptor,
+    UnaryInterceptor,
+)
+from ._interceptor_sync import (
+    BidiStreamInterceptorSync,
+    ClientStreamInterceptorSync,
+    InterceptorSync,
+    MetadataInterceptorSync,
+    ServerStreamInterceptorSync,
+    UnaryInterceptorSync,
+)
+
+__all__ = [
+    "UnaryInterceptor",
+    "ClientStreamInterceptor",
+    "ServerStreamInterceptor",
+    "BidiStreamInterceptor",
+    "Interceptor",
+    "MetadataInterceptor",
+    "BidiStreamInterceptorSync",
+    "ClientStreamInterceptorSync",
+    "InterceptorSync",
+    "MetadataInterceptorSync",
+    "ServerStreamInterceptorSync",
+    "UnaryInterceptorSync",
+]

--- a/src/connecpy/method.py
+++ b/src/connecpy/method.py
@@ -1,0 +1,59 @@
+import enum
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+REQ = TypeVar("REQ")
+RES = TypeVar("RES")
+
+
+class IdempotencyLevel(enum.Enum):
+    """The level of idempotency of an RPC method.
+
+    This value can affect RPC behaviors, such as determining whether it is safe to
+    retry a request, or what kinds of request modalities are allowed for a given
+    procedure.
+    """
+
+    UNKNOWN = enum.auto()
+    """The default idempotency level. 
+
+    A method with this idempotency level may not be idempotent. This is appropriate for
+    any kind of method.
+    """
+
+    NO_SIDE_EFFECTS = enum.auto()
+    """The idempotency level that specifies that a given call has no side-effects.
+
+    This is equivalent to [RFC 9110 § 9.2.1] "safe" methods in terms of semantics.
+    This procedure should not mutate any state. This idempotency level is appropriate
+    for queries, or anything that would be suitable for an HTTP GET request. In addition,
+    due to the lack of side-effects, such a procedure would be suitable to retry and
+    expect that the results will not be altered by preceding attempts.
+
+    [RFC 9110 § 9.2.1]: https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.1
+    """
+
+    IDEMPOTENT = enum.auto()
+    """The idempotency level that specifies that a given call is "idempotent", 
+    such that multiple instances of the same request to this procedure would have
+    the same side-effects as a single request.
+
+    This is equivalent to [RFC 9110 § 9.2.2] "idempotent" methods.
+    This level is a subset of the previous level. This idempotency level is
+    appropriate for any procedure that is safe to retry multiple times
+    and be guaranteed that the response and side-effects will not be altered
+    as a result of multiple attempts, for example, entity deletion requests.
+
+    [RFC 9110 § 9.2.2]: https://www.rfc-editor.org/rfc/rfc9110.html#section-9.2.2
+    """
+
+
+@dataclass(kw_only=True, frozen=True, slots=True)
+class MethodInfo(Generic[REQ, RES]):
+    """Information about a RPC method within a service."""
+
+    name: str
+    service_name: str
+    input: type[REQ]
+    output: type[RES]
+    idempotency_level: IdempotencyLevel

--- a/src/connecpy/server.py
+++ b/src/connecpy/server.py
@@ -2,7 +2,6 @@ from ._server_async import ConnecpyASGIApplication
 from ._server_shared import (
     Endpoint,
     EndpointSync,
-    ServerInterceptor,
     ServiceContext,
 )
 from ._server_sync import ConnecpyWSGIApplication
@@ -12,6 +11,5 @@ __all__ = [
     "ConnecpyWSGIApplication",
     "Endpoint",
     "EndpointSync",
-    "ServerInterceptor",
     "ServiceContext",
 ]

--- a/test/test_interceptor.py
+++ b/test/test_interceptor.py
@@ -1,0 +1,198 @@
+import itertools
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient, Client, WSGITransport
+
+from connecpy.server import ServiceContext
+from example.haberdasher_connecpy import (
+    Haberdasher,
+    HaberdasherASGIApplication,
+    HaberdasherClient,
+    HaberdasherClientSync,
+    HaberdasherSync,
+    HaberdasherWSGIApplication,
+)
+from example.haberdasher_pb2 import Hat, Size
+
+
+class RequestInterceptor:
+    result: str = ""
+
+    async def on_start(self, ctx: ServiceContext):
+        return self.on_start_sync(ctx)
+
+    async def on_end(self, token: str, ctx: ServiceContext):
+        self.on_end_sync(token, ctx)
+
+    def on_start_sync(self, ctx: ServiceContext):
+        return f"Hello {ctx.method().name}"
+
+    def on_end_sync(self, token: str, ctx: ServiceContext):
+        self.result = f"{token} and goodbye"
+
+
+@pytest.fixture
+def interceptor():
+    return RequestInterceptor()
+
+
+@pytest_asyncio.fixture
+async def client_async(interceptor: RequestInterceptor):
+    class SimpleHaberdasher(Haberdasher):
+        async def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+        async def MakeFlexibleHat(self, req, ctx):
+            size = 0
+            async for s in req:
+                size += s.inches
+            return Hat(size=size, color="red")
+
+        async def MakeSimilarHats(self, req, ctx):
+            yield Hat(size=req.inches, color="orange")
+            yield Hat(size=req.inches, color="blue")
+
+        async def MakeVariousHats(self, req, ctx):
+            colors = itertools.cycle(("black", "white", "gold"))
+            async for s in req:
+                yield Hat(size=s.inches, color=next(colors))
+
+    app = HaberdasherASGIApplication(SimpleHaberdasher(), interceptors=(interceptor,))
+    transport = ASGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete
+    async with HaberdasherClient(
+        "http://localhost",
+        session=AsyncClient(transport=transport),
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_intercept_unary_async(
+    client_async: HaberdasherClient, interceptor: RequestInterceptor
+):
+    result = await client_async.MakeHat(Size(inches=10))
+    assert result == Hat(size=10, color="green")
+    assert interceptor.result == "Hello MakeHat and goodbye"
+
+
+@pytest.mark.asyncio
+async def test_intercept_client_stream_async(
+    client_async: HaberdasherClient, interceptor: RequestInterceptor
+):
+    async def requests():
+        yield Size(inches=10)
+        yield Size(inches=20)
+
+    result = await client_async.MakeFlexibleHat(requests())
+    assert result == Hat(size=30, color="red")
+    assert interceptor.result == "Hello MakeFlexibleHat and goodbye"
+
+
+@pytest.mark.asyncio
+async def test_intercept_server_stream_async(
+    client_async: HaberdasherClient, interceptor: RequestInterceptor
+):
+    result = [r async for r in await client_async.MakeSimilarHats(Size(inches=15))]
+
+    assert result == [Hat(size=15, color="orange"), Hat(size=15, color="blue")]
+    assert interceptor.result == "Hello MakeSimilarHats and goodbye"
+
+
+@pytest.mark.asyncio
+async def test_intercept_bidi_stream_async(
+    client_async: HaberdasherClient, interceptor: RequestInterceptor
+):
+    async def requests():
+        yield Size(inches=25)
+        yield Size(inches=35)
+        yield Size(inches=45)
+
+    result = [r async for r in await client_async.MakeVariousHats(requests())]
+
+    assert result == [
+        Hat(size=25, color="black"),
+        Hat(size=35, color="white"),
+        Hat(size=45, color="gold"),
+    ]
+    assert interceptor.result == "Hello MakeVariousHats and goodbye"
+
+
+@pytest.fixture
+def client_sync(interceptor: RequestInterceptor):
+    class SimpleHaberdasherSync(HaberdasherSync):
+        def MakeHat(self, req, ctx):
+            return Hat(size=req.inches, color="green")
+
+        def MakeFlexibleHat(self, req, ctx):
+            size = 0
+            for s in req:
+                size += s.inches
+            return Hat(size=size, color="red")
+
+        def MakeSimilarHats(self, req, ctx):
+            yield Hat(size=req.inches, color="orange")
+            yield Hat(size=req.inches, color="blue")
+
+        def MakeVariousHats(self, req, ctx):
+            colors = itertools.cycle(("black", "white", "gold"))
+            requests = [*req]
+            for s in requests:
+                yield Hat(size=s.inches, color=next(colors))
+
+    app = HaberdasherWSGIApplication(
+        SimpleHaberdasherSync(), interceptors=(interceptor,)
+    )
+    transport = WSGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete
+    with HaberdasherClientSync(
+        "http://localhost",
+        session=Client(transport=transport),
+    ) as client:
+        yield client
+
+
+def test_intercept_unary_sync(
+    client_sync: HaberdasherClientSync, interceptor: RequestInterceptor
+):
+    result = client_sync.MakeHat(Size(inches=10))
+    assert result == Hat(size=10, color="green")
+    assert interceptor.result == "Hello MakeHat and goodbye"
+
+
+def test_intercept_client_stream_sync(
+    client_sync: HaberdasherClientSync, interceptor: RequestInterceptor
+):
+    def requests():
+        yield Size(inches=10)
+        yield Size(inches=20)
+
+    result = client_sync.MakeFlexibleHat(requests())
+    assert result == Hat(size=30, color="red")
+    assert interceptor.result == "Hello MakeFlexibleHat and goodbye"
+
+
+def test_intercept_server_stream_sync(
+    client_sync: HaberdasherClientSync, interceptor: RequestInterceptor
+):
+    result = [r for r in client_sync.MakeSimilarHats(Size(inches=15))]
+
+    assert result == [Hat(size=15, color="orange"), Hat(size=15, color="blue")]
+    assert interceptor.result == "Hello MakeSimilarHats and goodbye"
+
+
+def test_intercept_bidi_stream_sync(
+    client_sync: HaberdasherClientSync, interceptor: RequestInterceptor
+):
+    def requests():
+        yield Size(inches=25)
+        yield Size(inches=35)
+        yield Size(inches=45)
+
+    result = [r for r in client_sync.MakeVariousHats(requests())]
+
+    assert result == [
+        Hat(size=25, color="black"),
+        Hat(size=35, color="white"),
+        Hat(size=45, color="gold"),
+    ]
+    assert interceptor.result == "Hello MakeVariousHats and goodbye"


### PR DESCRIPTION
This reworks server invocation

- Endpoints are treated as a tagged union and functions are invoked with correct types
- Interceptor is reworked to be strongly typed for each stream type
- Information about a method is collected and exposed to interceptors (and servers) through context. This is similar to the information provided by other connect implementations
- Implement interceptor for sync

After this, I will wire interceptor into client as well and I think that completes general feature parity with other RPC frameworks