### PR TITLE
chore: rename variable name in interceptor and service protocols

### DIFF
--- a/conformance/test/connectrpc/conformance/v1/service_connecpy.py
+++ b/conformance/test/connectrpc/conformance/v1/service_connecpy.py
@@ -22,14 +22,14 @@ import connectrpc.conformance.v1.service_pb2 as connectrpc_dot_conformance_dot_v
 class ConformanceService(Protocol):
     async def Unary(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def ServerStream(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
         ctx: RequestContext,
     ) -> AsyncIterator[
         connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse
@@ -38,7 +38,7 @@ class ConformanceService(Protocol):
 
     async def ClientStream(
         self,
-        req: AsyncIterator[
+        request: AsyncIterator[
             connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest
         ],
         ctx: RequestContext,
@@ -47,7 +47,7 @@ class ConformanceService(Protocol):
 
     def BidiStream(
         self,
-        req: AsyncIterator[
+        request: AsyncIterator[
             connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest
         ],
         ctx: RequestContext,
@@ -58,14 +58,14 @@ class ConformanceService(Protocol):
 
     async def Unimplemented(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def IdempotentUnary(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
@@ -287,14 +287,14 @@ class ConformanceServiceClient(ConnecpyClient):
 class ConformanceServiceSync(Protocol):
     def Unary(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnaryResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def ServerStream(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamRequest,
         ctx: RequestContext,
     ) -> Iterator[
         connectrpc_dot_conformance_dot_v1_dot_service__pb2.ServerStreamResponse
@@ -303,7 +303,7 @@ class ConformanceServiceSync(Protocol):
 
     def ClientStream(
         self,
-        req: Iterator[
+        request: Iterator[
             connectrpc_dot_conformance_dot_v1_dot_service__pb2.ClientStreamRequest
         ],
         ctx: RequestContext,
@@ -312,7 +312,7 @@ class ConformanceServiceSync(Protocol):
 
     def BidiStream(
         self,
-        req: Iterator[
+        request: Iterator[
             connectrpc_dot_conformance_dot_v1_dot_service__pb2.BidiStreamRequest
         ],
         ctx: RequestContext,
@@ -323,14 +323,14 @@ class ConformanceServiceSync(Protocol):
 
     def Unimplemented(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.UnimplementedResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def IdempotentUnary(
         self,
-        req: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
+        request: connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryRequest,
         ctx: RequestContext,
     ) -> connectrpc_dot_conformance_dot_v1_dot_service__pb2.IdempotentUnaryResponse:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")

--- a/conformance/test/server.py
+++ b/conformance/test/server.py
@@ -140,24 +140,24 @@ async def _handle_unary_response(
 
 
 class TestService(ConformanceService):
-    async def Unary(self, req: UnaryRequest, ctx: RequestContext) -> UnaryResponse:
+    async def Unary(self, request: UnaryRequest, ctx: RequestContext) -> UnaryResponse:
         return await _handle_unary_response(
-            req.response_definition, [pack(req)], UnaryResponse(), ctx
+            request.response_definition, [pack(request)], UnaryResponse(), ctx
         )
 
     async def IdempotentUnary(
-        self, req: IdempotentUnaryRequest, ctx: RequestContext
+        self, request: IdempotentUnaryRequest, ctx: RequestContext
     ) -> IdempotentUnaryResponse:
         return await _handle_unary_response(
-            req.response_definition, [pack(req)], IdempotentUnaryResponse(), ctx
+            request.response_definition, [pack(request)], IdempotentUnaryResponse(), ctx
         )
 
     async def ClientStream(
-        self, req: AsyncIterator[ClientStreamRequest], ctx: RequestContext
+        self, request: AsyncIterator[ClientStreamRequest], ctx: RequestContext
     ) -> ClientStreamResponse:
         requests: list[Any] = []
         definition: UnaryResponseDefinition | None = None
-        async for message in req:
+        async for message in request:
             requests.append(pack(message))
             if not definition:
                 definition = message.response_definition
@@ -169,11 +169,11 @@ class TestService(ConformanceService):
         )
 
     async def ServerStream(
-        self, req: ServerStreamRequest, ctx: RequestContext
+        self, request: ServerStreamRequest, ctx: RequestContext
     ) -> AsyncIterator[ServerStreamResponse]:
-        definition = req.response_definition
+        definition = request.response_definition
         _send_headers(ctx, definition)
-        request_info = _create_request_info(ctx, [pack(req)])
+        request_info = _create_request_info(ctx, [pack(request)])
         sent_message = False
         for res_data in definition.response_data:
             res = ServerStreamResponse()
@@ -196,13 +196,13 @@ class TestService(ConformanceService):
             )
 
     async def BidiStream(
-        self, req: AsyncIterator[BidiStreamRequest], ctx: RequestContext
+        self, request: AsyncIterator[BidiStreamRequest], ctx: RequestContext
     ) -> AsyncIterator[BidiStreamResponse]:
         definition: StreamResponseDefinition | None = None
         full_duplex = False
         requests: list[Any] = []
         res_idx = 0
-        async for message in req:
+        async for message in request:
             if not definition:
                 definition = message.response_definition
                 _send_headers(ctx, definition)
@@ -271,24 +271,24 @@ def _handle_unary_response_sync(
 
 
 class TestServiceSync(ConformanceServiceSync):
-    def Unary(self, req: UnaryRequest, ctx: RequestContext) -> UnaryResponse:
+    def Unary(self, request: UnaryRequest, ctx: RequestContext) -> UnaryResponse:
         return _handle_unary_response_sync(
-            req.response_definition, [pack(req)], UnaryResponse(), ctx
+            request.response_definition, [pack(request)], UnaryResponse(), ctx
         )
 
     def IdempotentUnary(
-        self, req: IdempotentUnaryRequest, ctx: RequestContext
+        self, request: IdempotentUnaryRequest, ctx: RequestContext
     ) -> IdempotentUnaryResponse:
         return _handle_unary_response_sync(
-            req.response_definition, [pack(req)], IdempotentUnaryResponse(), ctx
+            request.response_definition, [pack(request)], IdempotentUnaryResponse(), ctx
         )
 
     def ClientStream(
-        self, req: Iterator[ClientStreamRequest], ctx: RequestContext
+        self, request: Iterator[ClientStreamRequest], ctx: RequestContext
     ) -> ClientStreamResponse:
         requests: list[Any] = []
         definition: UnaryResponseDefinition | None = None
-        for message in req:
+        for message in request:
             requests.append(pack(message))
             if not definition:
                 definition = message.response_definition
@@ -300,11 +300,11 @@ class TestServiceSync(ConformanceServiceSync):
         )
 
     def ServerStream(
-        self, req: ServerStreamRequest, ctx: RequestContext
+        self, request: ServerStreamRequest, ctx: RequestContext
     ) -> Iterator[ServerStreamResponse]:
-        definition = req.response_definition
+        definition = request.response_definition
         _send_headers(ctx, definition)
-        request_info = _create_request_info(ctx, [pack(req)])
+        request_info = _create_request_info(ctx, [pack(request)])
         sent_message = False
         for res_data in definition.response_data:
             res = ServerStreamResponse()
@@ -327,13 +327,13 @@ class TestServiceSync(ConformanceServiceSync):
             )
 
     def BidiStream(
-        self, req: Iterator[BidiStreamRequest], ctx: RequestContext
+        self, request: Iterator[BidiStreamRequest], ctx: RequestContext
     ) -> Iterator[BidiStreamResponse]:
         definition: StreamResponseDefinition | None = None
         full_duplex = False
         requests: list[Any] = []
         res_idx = 0
-        for message in req:
+        for message in request:
             if not definition:
                 definition = message.response_definition
                 _send_headers(ctx, definition)

--- a/example/example/haberdasher_connecpy.py
+++ b/example/example/haberdasher_connecpy.py
@@ -22,27 +22,31 @@ import google.protobuf.empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 class Haberdasher(Protocol):
     async def MakeHat(
-        self, req: example_dot_haberdasher__pb2.Size, ctx: RequestContext
+        self, request: example_dot_haberdasher__pb2.Size, ctx: RequestContext
     ) -> example_dot_haberdasher__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def MakeFlexibleHat(
-        self, req: AsyncIterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
+        self,
+        request: AsyncIterator[example_dot_haberdasher__pb2.Size],
+        ctx: RequestContext,
     ) -> example_dot_haberdasher__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def MakeSimilarHats(
-        self, req: example_dot_haberdasher__pb2.Size, ctx: RequestContext
+        self, request: example_dot_haberdasher__pb2.Size, ctx: RequestContext
     ) -> AsyncIterator[example_dot_haberdasher__pb2.Hat]:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def MakeVariousHats(
-        self, req: AsyncIterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
+        self,
+        request: AsyncIterator[example_dot_haberdasher__pb2.Size],
+        ctx: RequestContext,
     ) -> AsyncIterator[example_dot_haberdasher__pb2.Hat]:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     async def DoNothing(
-        self, req: google_dot_protobuf_dot_empty__pb2.Empty, ctx: RequestContext
+        self, request: google_dot_protobuf_dot_empty__pb2.Empty, ctx: RequestContext
     ) -> google_dot_protobuf_dot_empty__pb2.Empty:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
@@ -224,27 +228,27 @@ class HaberdasherClient(ConnecpyClient):
 
 class HaberdasherSync(Protocol):
     def MakeHat(
-        self, req: example_dot_haberdasher__pb2.Size, ctx: RequestContext
+        self, request: example_dot_haberdasher__pb2.Size, ctx: RequestContext
     ) -> example_dot_haberdasher__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def MakeFlexibleHat(
-        self, req: Iterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
+        self, request: Iterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
     ) -> example_dot_haberdasher__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def MakeSimilarHats(
-        self, req: example_dot_haberdasher__pb2.Size, ctx: RequestContext
+        self, request: example_dot_haberdasher__pb2.Size, ctx: RequestContext
     ) -> Iterator[example_dot_haberdasher__pb2.Hat]:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def MakeVariousHats(
-        self, req: Iterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
+        self, request: Iterator[example_dot_haberdasher__pb2.Size], ctx: RequestContext
     ) -> Iterator[example_dot_haberdasher__pb2.Hat]:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
     def DoNothing(
-        self, req: google_dot_protobuf_dot_empty__pb2.Empty, ctx: RequestContext
+        self, request: google_dot_protobuf_dot_empty__pb2.Empty, ctx: RequestContext
     ) -> google_dot_protobuf_dot_empty__pb2.Empty:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 

--- a/example/example/haberdasher_edition_2023_connecpy.py
+++ b/example/example/haberdasher_edition_2023_connecpy.py
@@ -21,7 +21,9 @@ import example.haberdasher_edition_2023_pb2 as example_dot_haberdasher__edition_
 
 class Haberdasher(Protocol):
     async def MakeHat(
-        self, req: example_dot_haberdasher__edition__2023__pb2.Size, ctx: RequestContext
+        self,
+        request: example_dot_haberdasher__edition__2023__pb2.Size,
+        ctx: RequestContext,
     ) -> example_dot_haberdasher__edition__2023__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 
@@ -83,7 +85,9 @@ class HaberdasherClient(ConnecpyClient):
 
 class HaberdasherSync(Protocol):
     def MakeHat(
-        self, req: example_dot_haberdasher__edition__2023__pb2.Size, ctx: RequestContext
+        self,
+        request: example_dot_haberdasher__edition__2023__pb2.Size,
+        ctx: RequestContext,
     ) -> example_dot_haberdasher__edition__2023__pb2.Hat:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 

--- a/example/example/server.py
+++ b/example/example/server.py
@@ -15,12 +15,12 @@ class MyInterceptor:
 
     async def intercept_unary(
         self,
-        next: Callable[[T, RequestContext], Awaitable[U]],
+        call_next: Callable[[T, RequestContext], Awaitable[U]],
         request: T,
         ctx: RequestContext,
     ) -> U:
         print(f"intercepting {ctx.method().name} with {self._msg}")
-        return await next(request, ctx)
+        return await call_next(request, ctx)
 
 
 my_interceptor_a = MyInterceptor("A")

--- a/example/example/service.py
+++ b/example/example/service.py
@@ -9,14 +9,14 @@ from .haberdasher_pb2 import Hat, Size
 
 
 class HaberdasherService(Haberdasher):
-    async def MakeHat(self, req: Size, ctx: RequestContext) -> Hat:
+    async def MakeHat(self, request: Size, ctx: RequestContext) -> Hat:
         print("remaining_time: ", ctx.timeout_ms())
-        if req.inches <= 0:
+        if request.inches <= 0:
             raise ConnecpyException(
                 Code.INVALID_ARGUMENT, "inches I can't make a hat that small!"
             )
         response = Hat(
-            size=req.inches,
+            size=request.inches,
             color=random.choice(["white", "black", "brown", "red", "blue"]),
         )
         if random.random() > 0.5:

--- a/example/example/wsgi_service.py
+++ b/example/example/wsgi_service.py
@@ -9,14 +9,14 @@ from .haberdasher_pb2 import Hat, Size
 
 
 class HaberdasherService(HaberdasherSync):
-    def MakeHat(self, req: Size, ctx: RequestContext) -> Hat:
+    def MakeHat(self, request: Size, ctx: RequestContext) -> Hat:
         print("remaining_time: ", ctx.timeout_ms())
-        if req.inches <= 0:
+        if request.inches <= 0:
             raise ConnecpyException(
                 Code.INVALID_ARGUMENT, "inches I can't make a hat that small!"
             )
         response = Hat(
-            size=req.inches,
+            size=request.inches,
             color=random.choice(["white", "black", "brown", "red", "blue"]),
         )
         if random.random() > 0.5:

--- a/noextras/test/test_compression_default.py
+++ b/noextras/test/test_compression_default.py
@@ -19,8 +19,8 @@ from httpx import (
 @pytest.mark.parametrize("compression", ["gzip", "identity", None])
 def test_roundtrip_sync(compression: str):
     class RoundtripHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req, ctx):
-            return Hat(size=req.inches, color="green")
+        def MakeHat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
 
     app = HaberdasherWSGIApplication(RoundtripHaberdasherSync())
     with HaberdasherClientSync(
@@ -38,8 +38,8 @@ def test_roundtrip_sync(compression: str):
 @pytest.mark.asyncio
 async def test_roundtrip_async(compression: str):
     class DetailsHaberdasher(Haberdasher):
-        async def MakeHat(self, req, ctx):
-            return Hat(size=req.inches, color="green")
+        async def MakeHat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
 
     app = HaberdasherASGIApplication(DetailsHaberdasher())
     transport = ASGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete
@@ -57,8 +57,8 @@ async def test_roundtrip_async(compression: str):
 @pytest.mark.parametrize("compression", ["br", "zstd"])
 def test_invalid_compression_sync(compression: str):
     class RoundtripHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req, ctx):
-            return Hat(size=req.inches, color="green")
+        def MakeHat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
 
     app = HaberdasherWSGIApplication(RoundtripHaberdasherSync())
 
@@ -79,8 +79,8 @@ def test_invalid_compression_sync(compression: str):
 @pytest.mark.asyncio
 async def test_invalid_compression_async(compression: str):
     class DetailsHaberdasher(Haberdasher):
-        async def MakeHat(self, req, ctx):
-            return Hat(size=req.inches, color="green")
+        async def MakeHat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
 
     app = HaberdasherASGIApplication(DetailsHaberdasher())
     transport = ASGITransport(app)  # pyright:ignore[reportArgumentType] - httpx type is not complete

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -60,7 +60,7 @@ import {{.Name}} as {{.Alias}}
 
 
 class {{.Name}}(Protocol):{{- range .Methods }}
-    {{if not .ResponseStream }}async {{end}}def {{.Name}}(self, req: {{if .RequestStream}}AsyncIterator[{{end}}{{.InputType}}{{if .RequestStream}}]{{end}}, ctx: RequestContext) -> {{if .ResponseStream}}AsyncIterator[{{end}}{{.OutputType}}{{if .ResponseStream}}]{{end}}:
+    {{if not .ResponseStream }}async {{end}}def {{.Name}}(self, request: {{if .RequestStream}}AsyncIterator[{{end}}{{.InputType}}{{if .RequestStream}}]{{end}}, ctx: RequestContext) -> {{if .ResponseStream}}AsyncIterator[{{end}}{{.OutputType}}{{if .ResponseStream}}]{{end}}:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 {{ end }}
 
@@ -114,7 +114,7 @@ class {{.Name}}Client(ConnecpyClient):{{range .Methods}}
 {{end}}{{- end }}
 {{range .Services}}
 class {{.Name}}Sync(Protocol):{{- range .Methods }}
-    def {{.Name}}(self, req: {{if .RequestStream}}Iterator[{{end}}{{.InputType}}{{if .RequestStream}}]{{end}}, ctx: RequestContext) -> {{if .ResponseStream}}Iterator[{{end}}{{.OutputType}}{{if .ResponseStream}}]{{end}}:
+    def {{.Name}}(self, request: {{if .RequestStream}}Iterator[{{end}}{{.InputType}}{{if .RequestStream}}]{{end}}, ctx: RequestContext) -> {{if .ResponseStream}}Iterator[{{end}}{{.OutputType}}{{if .ResponseStream}}]{{end}}:
         raise ConnecpyException(Code.UNIMPLEMENTED, "Not implemented")
 {{- end }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,43 @@ build-backend = "uv_build"
 [tool.pytest.ini_options]
 testpaths = ["test"]
 
+[tool.ruff.lint]
+extend-select = [
+    # Same order as listed on https://docs.astral.sh/ruff/rules/
+    "YTT",
+    # TODO: Enable after adding more type annotations
+    # "ANN",
+    "ASYNC",
+    "S",
+    "FBT",
+    "B",
+    "A",
+    "COM818", # Other comma rules are handled by formatting
+    "C4",
+    "DTZ",
+    "T10",
+]
+
+# Document reasons for ignoring specific linting errors
+extend-ignore = [
+    # Not applicable
+    "AIR",
+    # Dangerous false positives https://github.com/astral-sh/ruff/issues/4845
+    "ERA",
+    # Important to call user callbacks safely
+    "BLE",
+    # stdlib includes a module named code. This is less of an issue since users need to import a module so allow it
+    "A005",
+    # TODO: Consider using copyright headers
+    "CPY",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"example/**" = [
+    "S", # Keep examples simpler, e.g. allow normal random
+]
+"**/test_*.py" = ["S101", "S603", "S607", "FBT"]
+
 [tool.ruff]
 # Don't run ruff on generated code from external plugins.
 extend-exclude = ["*_pb2.py", "*_pb2.pyi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ extend-ignore = [
     "AIR",
     # Dangerous false positives https://github.com/astral-sh/ruff/issues/4845
     "ERA",
+    # Not Applicable
+    "FAST",
     # Important to call user callbacks safely
     "BLE",
     # stdlib includes a module named code. This is less of an issue since users need to import a module so allow it

--- a/src/connecpy/_client_async.py
+++ b/src/connecpy/_client_async.py
@@ -302,14 +302,14 @@ class ConnecpyClient:
                 return response
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
-        except (httpx.TimeoutException, TimeoutError):
-            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except (httpx.TimeoutException, TimeoutError) as e:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out") from e
         except ConnecpyException:
             raise
         except CancelledError as e:
             raise ConnecpyException(Code.CANCELED, "Request was cancelled") from e
         except Exception as e:
-            raise ConnecpyException(Code.UNAVAILABLE, str(e))
+            raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
     async def _send_request_client_stream(
         self,
@@ -380,14 +380,14 @@ class ConnecpyClient:
                     await resp.aclose()
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
-        except (httpx.TimeoutException, TimeoutError):
-            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except (httpx.TimeoutException, TimeoutError) as e:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out") from e
         except ConnecpyException:
             raise
         except CancelledError as e:
             raise ConnecpyException(Code.CANCELED, "Request was cancelled") from e
         except Exception as e:
-            raise ConnecpyException(Code.UNAVAILABLE, str(e))
+            raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
 
 def _convert_connect_timeout(timeout_ms: Optional[float]) -> Timeout:

--- a/src/connecpy/_client_sync.py
+++ b/src/connecpy/_client_sync.py
@@ -296,12 +296,12 @@ class ConnecpyClientSync:
                 return response
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
-        except (httpx.TimeoutException, TimeoutError):
-            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except (httpx.TimeoutException, TimeoutError) as e:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out") from e
         except ConnecpyException:
             raise
         except Exception as e:
-            raise ConnecpyException(Code.UNAVAILABLE, str(e))
+            raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
     def _send_request_client_stream(
         self,
@@ -361,12 +361,12 @@ class ConnecpyClientSync:
                     resp.close()
             else:
                 raise ConnectWireError.from_response(resp).to_exception()
-        except (httpx.TimeoutException, TimeoutError):
-            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out")
+        except (httpx.TimeoutException, TimeoutError) as e:
+            raise ConnecpyException(Code.DEADLINE_EXCEEDED, "Request timed out") from e
         except ConnecpyException:
             raise
         except Exception as e:
-            raise ConnecpyException(Code.UNAVAILABLE, str(e))
+            raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
 
 # Convert a timeout with connect semantics to a httpx.Timeout. Connect timeouts

--- a/src/connecpy/_interceptor_async.py
+++ b/src/connecpy/_interceptor_async.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 class UnaryInterceptor(Protocol):
     async def intercept_unary(
         self,
-        next: Callable[[REQ, RequestContext], Awaitable[RES]],
+        call_next: Callable[[REQ, RequestContext], Awaitable[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> RES:
@@ -33,7 +33,7 @@ class UnaryInterceptor(Protocol):
 class ClientStreamInterceptor(Protocol):
     async def intercept_client_stream(
         self,
-        next: Callable[[AsyncIterator[REQ], RequestContext], Awaitable[RES]],
+        call_next: Callable[[AsyncIterator[REQ], RequestContext], Awaitable[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
     ) -> RES:
@@ -45,7 +45,7 @@ class ClientStreamInterceptor(Protocol):
 class ServerStreamInterceptor(Protocol):
     def intercept_server_stream(
         self,
-        next: Callable[[REQ, RequestContext], AsyncIterator[RES]],
+        call_next: Callable[[REQ, RequestContext], AsyncIterator[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> AsyncIterator[RES]:
@@ -57,7 +57,7 @@ class ServerStreamInterceptor(Protocol):
 class BidiStreamInterceptor(Protocol):
     def intercept_bidi_stream(
         self,
-        next: Callable[[AsyncIterator[REQ], RequestContext], AsyncIterator[RES]],
+        call_next: Callable[[AsyncIterator[REQ], RequestContext], AsyncIterator[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
     ) -> AsyncIterator[RES]:
@@ -103,50 +103,50 @@ class MetadataInterceptorInvoker(Generic[T]):
 
     async def intercept_unary(
         self,
-        next: Callable[[REQ, RequestContext], Awaitable[RES]],
+        call_next: Callable[[REQ, RequestContext], Awaitable[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> RES:
         token = await self._delegate.on_start(ctx)
         try:
-            return await next(request, ctx)
+            return await call_next(request, ctx)
         finally:
             await self._delegate.on_end(token, ctx)
 
     async def intercept_client_stream(
         self,
-        next: Callable[[AsyncIterator[REQ], RequestContext], Awaitable[RES]],
+        call_next: Callable[[AsyncIterator[REQ], RequestContext], Awaitable[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
     ) -> RES:
         token = await self._delegate.on_start(ctx)
         try:
-            return await next(request, ctx)
+            return await call_next(request, ctx)
         finally:
             await self._delegate.on_end(token, ctx)
 
     async def intercept_server_stream(
         self,
-        next: Callable[[REQ, RequestContext], AsyncIterator[RES]],
+        call_next: Callable[[REQ, RequestContext], AsyncIterator[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> AsyncIterator[RES]:
         token = await self._delegate.on_start(ctx)
         try:
-            async for response in next(request, ctx):
+            async for response in call_next(request, ctx):
                 yield response
         finally:
             await self._delegate.on_end(token, ctx)
 
     async def intercept_bidi_stream(
         self,
-        next: Callable[[AsyncIterator[REQ], RequestContext], AsyncIterator[RES]],
+        call_next: Callable[[AsyncIterator[REQ], RequestContext], AsyncIterator[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
     ) -> AsyncIterator[RES]:
         token = await self._delegate.on_start(ctx)
         try:
-            async for response in next(request, ctx):
+            async for response in call_next(request, ctx):
                 yield response
         finally:
             await self._delegate.on_end(token, ctx)

--- a/src/connecpy/_interceptor_sync.py
+++ b/src/connecpy/_interceptor_sync.py
@@ -20,7 +20,7 @@ T = TypeVar("T")
 class UnaryInterceptorSync(Protocol):
     def intercept_unary_sync(
         self,
-        next: Callable[[REQ, RequestContext], RES],
+        call_next: Callable[[REQ, RequestContext], RES],
         request: REQ,
         ctx: RequestContext,
     ) -> RES:
@@ -32,7 +32,7 @@ class UnaryInterceptorSync(Protocol):
 class ClientStreamInterceptorSync(Protocol):
     def intercept_client_stream_sync(
         self,
-        next: Callable[[Iterator[REQ], RequestContext], RES],
+        call_next: Callable[[Iterator[REQ], RequestContext], RES],
         request: Iterator[REQ],
         ctx: RequestContext,
     ) -> RES:
@@ -44,7 +44,7 @@ class ClientStreamInterceptorSync(Protocol):
 class ServerStreamInterceptorSync(Protocol):
     def intercept_server_stream_sync(
         self,
-        next: Callable[[REQ, RequestContext], Iterator[RES]],
+        call_next: Callable[[REQ, RequestContext], Iterator[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> Iterator[RES]:
@@ -56,7 +56,7 @@ class ServerStreamInterceptorSync(Protocol):
 class BidiStreamInterceptorSync(Protocol):
     def intercept_bidi_stream_sync(
         self,
-        next: Callable[[Iterator[REQ], RequestContext], Iterator[RES]],
+        call_next: Callable[[Iterator[REQ], RequestContext], Iterator[RES]],
         request: Iterator[REQ],
         ctx: RequestContext,
     ) -> Iterator[RES]:
@@ -102,49 +102,49 @@ class MetadataInterceptorInvokerSync(Generic[T]):
 
     def intercept_unary_sync(
         self,
-        next: Callable[[REQ, RequestContext], RES],
+        call_next: Callable[[REQ, RequestContext], RES],
         request: REQ,
         ctx: RequestContext,
     ) -> RES:
         token = self._delegate.on_start_sync(ctx)
         try:
-            return next(request, ctx)
+            return call_next(request, ctx)
         finally:
             self._delegate.on_end_sync(token, ctx)
 
     def intercept_client_stream_sync(
         self,
-        next: Callable[[Iterator[REQ], RequestContext], RES],
+        call_next: Callable[[Iterator[REQ], RequestContext], RES],
         request: Iterator[REQ],
         ctx: RequestContext,
     ) -> RES:
         token = self._delegate.on_start_sync(ctx)
         try:
-            return next(request, ctx)
+            return call_next(request, ctx)
         finally:
             self._delegate.on_end_sync(token, ctx)
 
     def intercept_server_stream_sync(
         self,
-        next: Callable[[REQ, RequestContext], Iterator[RES]],
+        call_next: Callable[[REQ, RequestContext], Iterator[RES]],
         request: REQ,
         ctx: RequestContext,
     ) -> Iterator[RES]:
         token = self._delegate.on_start_sync(ctx)
         try:
-            yield from next(request, ctx)
+            yield from call_next(request, ctx)
         finally:
             self._delegate.on_end_sync(token, ctx)
 
     def intercept_bidi_stream_sync(
         self,
-        next: Callable[[Iterator[REQ], RequestContext], Iterator[RES]],
+        call_next: Callable[[Iterator[REQ], RequestContext], Iterator[RES]],
         request: Iterator[REQ],
         ctx: RequestContext,
     ) -> Iterator[RES]:
         token = self._delegate.on_start_sync(ctx)
         try:
-            yield from next(request, ctx)
+            yield from call_next(request, ctx)
         finally:
             self._delegate.on_end_sync(token, ctx)
 

--- a/src/connecpy/_protocol.py
+++ b/src/connecpy/_protocol.py
@@ -188,7 +188,7 @@ class HTTPException(Exception):
         self.headers = headers
 
 
-def codec_name_from_content_type(content_type: str, stream: bool) -> str:
+def codec_name_from_content_type(content_type: str, *, stream: bool) -> str:
     prefix = (
         CONNECT_STREAMING_CONTENT_TYPE_PREFIX
         if stream

--- a/src/connecpy/_server_async.py
+++ b/src/connecpy/_server_async.py
@@ -94,7 +94,7 @@ class ConnecpyASGIApplication(ABC):
             receive (callable): The ASGI receive function.
             send (callable): The ASGI send function.
         """
-        assert scope["type"] == "http"
+        assert scope["type"] == "http"  # noqa: S101 - only for type narrowing, in practice always true
 
         ctx: Optional[RequestContext] = None
         try:
@@ -124,7 +124,7 @@ class ConnecpyASGIApplication(ABC):
             else:
                 query_params = _UNSET_QUERY_PARAMS
                 codec_name = codec_name_from_content_type(
-                    headers.get("content-type", ""), not is_unary
+                    headers.get("content-type", ""), stream=not is_unary
                 )
             codec = get_codec(codec_name.lower())
             if not codec:
@@ -235,10 +235,10 @@ class ConnecpyASGIApplication(ABC):
         if is_base64:
             try:
                 message = base64.urlsafe_b64decode(message + "===")
-            except Exception:
+            except Exception as e:
                 raise ConnecpyException(
                     Code.INVALID_ARGUMENT, "Invalid base64 encoding"
-                )
+                ) from e
         else:
             message = message.encode("utf-8")
 

--- a/src/connecpy/_server_sync.py
+++ b/src/connecpy/_server_sync.py
@@ -270,7 +270,7 @@ class ConnecpyWSGIApplication(ABC):
         """Handle POST request with body."""
 
         codec_name = codec_name_from_content_type(
-            request_headers.get("content-type", ""), False
+            request_headers.get("content-type", ""), stream=False
         )
         codec = get_codec(codec_name)
         if not codec:
@@ -308,7 +308,7 @@ class ConnecpyWSGIApplication(ABC):
                     raise ConnecpyException(
                         Code.INVALID_ARGUMENT,
                         f"Failed to decompress request body: {str(e)}",
-                    )
+                    ) from e
 
             if (
                 self._read_max_bytes is not None
@@ -324,14 +324,14 @@ class ConnecpyWSGIApplication(ABC):
             except Exception as e:
                 raise ConnecpyException(
                     Code.INVALID_ARGUMENT, f"Failed to decode request body: {str(e)}"
-                )
+                ) from e
 
         except Exception as e:
             if not isinstance(e, ConnecpyException):
                 raise ConnecpyException(
                     Code.INTERNAL,
                     str(e),  # TODO
-                )
+                ) from e
             raise
 
     def _handle_get_request(
@@ -356,7 +356,7 @@ class ConnecpyWSGIApplication(ABC):
                 except Exception as e:
                     raise ConnecpyException(
                         Code.INVALID_ARGUMENT, f"Invalid base64 encoding: {str(e)}"
-                    )
+                    ) from e
             else:
                 message = message.encode("utf-8")
 
@@ -385,11 +385,11 @@ class ConnecpyWSGIApplication(ABC):
             except Exception as e:
                 raise ConnecpyException(
                     Code.INVALID_ARGUMENT, f"Failed to decode message: {str(e)}"
-                )
+                ) from e
 
         except Exception as e:
             if not isinstance(e, ConnecpyException):
-                raise ConnecpyException(Code.INTERNAL, str(e))
+                raise ConnecpyException(Code.INTERNAL, str(e)) from e
             raise
 
     def _handle_stream(
@@ -408,7 +408,9 @@ class ConnecpyWSGIApplication(ABC):
         response_compression_name = _compression.select_encoding(accept_compression)
         response_compression = _compression.get_compression(response_compression_name)
 
-        codec_name = codec_name_from_content_type(headers.get("content-type", ""), True)
+        codec_name = codec_name_from_content_type(
+            headers.get("content-type", ""), stream=True
+        )
         codec = get_codec(codec_name)
         if not codec:
             raise HTTPException(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -58,7 +58,7 @@ def test_headers_sync(headers, trailers, response_headers, response_trailers):
             self.headers = headers
             self.trailers = trailers
 
-        def MakeHat(self, req, ctx):
+        def MakeHat(self, request, ctx):
             for key, value in self.headers:
                 ctx.response_headers().add(key, value)
             for key, value in self.trailers:
@@ -92,7 +92,7 @@ async def test_headers_async(headers, trailers, response_headers, response_trail
             self.headers = headers
             self.trailers = trailers
 
-        async def MakeHat(self, req, ctx):
+        async def MakeHat(self, request, ctx):
             for key, value in self.headers:
                 ctx.response_headers().add(key, value)
             for key, value in self.trailers:

--- a/test/test_details.py
+++ b/test/test_details.py
@@ -23,7 +23,7 @@ from example.haberdasher_pb2 import Size
 
 def test_details_sync():
     class DetailsHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req, ctx):
+        def MakeHat(self, request, ctx):
             raise ConnecpyException(
                 Code.RESOURCE_EXHAUSTED,
                 "Resource exhausted",
@@ -55,7 +55,7 @@ def test_details_sync():
 @pytest.mark.asyncio
 async def test_details_async():
     class DetailsHaberdasher(Haberdasher):
-        async def MakeHat(self, req, ctx):
+        async def MakeHat(self, request, ctx):
             raise ConnecpyException(
                 Code.RESOURCE_EXHAUSTED,
                 "Resource exhausted",

--- a/test/test_edition_2023.py
+++ b/test/test_edition_2023.py
@@ -19,8 +19,8 @@ def test_edition_2023_service_generation():
 
     # Create a simple service implementation
     class TestHaberdasher(Haberdasher):
-        async def MakeHat(self, req: Size, ctx: RequestContext) -> Hat:
-            return Hat(size=req.inches, color="blue", name="test")
+        async def MakeHat(self, request: Size, ctx: RequestContext) -> Hat:
+            return Hat(size=request.inches, color="blue", name="test")
 
     # Verify the service can be instantiated
     service = TestHaberdasher()
@@ -29,8 +29,8 @@ def test_edition_2023_service_generation():
 
     # Verify sync version works too
     class TestHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req: Size, ctx: RequestContext) -> Hat:
-            return Hat(size=req.inches, color="red", name="test")
+        def MakeHat(self, request: Size, ctx: RequestContext) -> Hat:
+            return Hat(size=request.inches, color="red", name="test")
 
     sync_service = TestHaberdasherSync()
     sync_app = HaberdasherWSGIApplication(sync_service)

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -59,7 +59,7 @@ def test_sync_errors(
         def __init__(self, exception: ConnecpyException):
             self._exception = exception
 
-        def MakeHat(self, req, ctx):
+        def MakeHat(self, request, ctx):
             raise self._exception
 
     haberdasher = ErrorHaberdasherSync(ConnecpyException(code, message))
@@ -97,7 +97,7 @@ async def test_async_errors(
         def __init__(self, exception: ConnecpyException):
             self._exception = exception
 
-        async def MakeHat(self, req, ctx):
+        async def MakeHat(self, request, ctx):
             raise self._exception
 
     haberdasher = ErrorHaberdasher(ConnecpyException(code, message))
@@ -265,7 +265,7 @@ def test_sync_client_errors(
     method, path, headers, body, response_status, response_headers
 ):
     class ValidHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req, ctx):
+        def MakeHat(self, request, ctx):
             return Hat()
 
     app = HaberdasherWSGIApplication(ValidHaberdasherSync())
@@ -291,7 +291,7 @@ async def test_async_client_errors(
     method, path, headers, body, response_status, response_headers
 ):
     class ValidHaberdasher(Haberdasher):
-        async def MakeHat(self, req, ctx):
+        async def MakeHat(self, request, ctx):
             return Hat()
 
     haberdasher = ValidHaberdasher()
@@ -314,7 +314,7 @@ async def test_async_client_errors(
 @pytest.fixture(scope="module")
 def sync_timeout_server():
     class SleepingHaberdasherSync(HaberdasherSync):
-        def MakeHat(self, req, ctx):
+        def MakeHat(self, request, ctx):
             time.sleep(10)
             raise AssertionError("Should be timedout already")
 


### PR DESCRIPTION
Sorry, I thought I was done with big changes and just wanted to enable linters...

But when enabling [flake8-builtins](https://docs.astral.sh/ruff/rules/#flake8-builtins-a) I realized the interceptor protocol definition isn't good since `next` shadows a builtin. Because type checkers require the variable name to be the same, it causes user code to follow the bad practice. I renamed to `call_next`.

And then I went ahead and renamed the variable for the service to `request` to be consistent with the interceptor - I could instead rename the interceptor to `req` but it seemed better to have the more explicit name for it but let me know if otherwise.

This also enables/ignores all linters down to DJ, with a few small fixes related to them. Stopping there to make sure this interface change doesn't get bunched up with too many lint fixes.