### PR TITLE
chore: format without trailing commas

### DIFF
--- a/conformance/test/client.py
+++ b/conformance/test/client.py
@@ -101,8 +101,7 @@ def _unpack_request(message: Any, request: T) -> T:
 
 
 async def _run_test(
-    mode: Literal["sync", "async"],
-    test_request: ClientCompatRequest,
+    mode: Literal["sync", "async"], test_request: ClientCompatRequest
 ) -> ClientCompatResponse:
     test_response = ClientCompatResponse()
     test_response.test_name = test_request.test_name
@@ -419,8 +418,7 @@ async def _run_test(
 
                                 task = asyncio.create_task(
                                     send_client_stream_request(
-                                        client,
-                                        client_stream_request(),
+                                        client, client_stream_request()
                                     )
                                 )
                             case "IdempotentUnary":

--- a/conformance/test/server.py
+++ b/conformance/test/server.py
@@ -121,10 +121,7 @@ def _create_request_info(
 
 
 async def _handle_unary_response(
-    definition: UnaryResponseDefinition,
-    reqs: list[Any],
-    res: RES,
-    ctx: RequestContext,
+    definition: UnaryResponseDefinition, reqs: list[Any], res: RES, ctx: RequestContext
 ) -> RES:
     _send_headers(ctx, definition)
     request_info = _create_request_info(ctx, reqs)
@@ -253,10 +250,7 @@ class TestService(ConformanceService):
 
 
 def _handle_unary_response_sync(
-    definition: UnaryResponseDefinition,
-    reqs: list[Any],
-    res: RES,
-    ctx: RequestContext,
+    definition: UnaryResponseDefinition, reqs: list[Any], res: RES, ctx: RequestContext
 ) -> RES:
     _send_headers(ctx, definition)
     request_info = _create_request_info(ctx, reqs)

--- a/example/example/client.py
+++ b/example/example/client.py
@@ -10,10 +10,7 @@ timeout_s = 5
 
 
 async def main():
-    async with httpx.AsyncClient(
-        base_url=server_url,
-        timeout=timeout_s,
-    ) as session:
+    async with httpx.AsyncClient(base_url=server_url, timeout=timeout_s) as session:
         # Example 1: POST request with Zstandard compression, receiving Brotli compressed response
         async with haberdasher_connecpy.HaberdasherClient(
             server_url,
@@ -25,7 +22,7 @@ async def main():
                 response = await client.make_hat(
                     request=haberdasher_pb2.Size(inches=12),
                     headers={
-                        "Content-Encoding": "zstd",  # Request compression
+                        "Content-Encoding": "zstd"  # Request compression
                     },
                 )
                 print("POST with Zstandard and Brotli compression:", response)
@@ -34,9 +31,7 @@ async def main():
 
         # Example 2: GET request, receiving Zstandard compressed response
         async with haberdasher_connecpy.HaberdasherClient(
-            server_url,
-            session=session,
-            accept_compression=["zstd"],
+            server_url, session=session, accept_compression=["zstd"]
         ) as client:
             try:
                 response = await client.make_hat(

--- a/example/example/client_sync.py
+++ b/example/example/client_sync.py
@@ -24,9 +24,7 @@ def main():
     ) as client:
         try:
             print("\nTesting POST request with gzip compression...")
-            response = client.make_hat(
-                request=create_large_request(),
-            )
+            response = client.make_hat(request=create_large_request())
             print("POST with gzip compression successful:", response)
         except ConnecpyException as e:
             print("POST with gzip compression failed:", str(e))
@@ -40,9 +38,7 @@ def main():
     ) as client:
         try:
             print("\nTesting POST request with brotli compression...")
-            response = client.make_hat(
-                request=create_large_request(),
-            )
+            response = client.make_hat(request=create_large_request())
             print("POST with brotli compression successful:", response)
         except ConnecpyException as e:
             print("POST with brotli compression failed:", str(e))
@@ -70,25 +66,18 @@ def main():
     ) as client:
         try:
             print("\nTesting GET request with gzip compression...")
-            response = client.make_hat(
-                request=create_large_request(),
-                use_get=True,
-            )
+            response = client.make_hat(request=create_large_request(), use_get=True)
             print("GET with zstd compression successful:", response)
         except ConnecpyException as e:
             print("GET with zstd compression failed:", str(e))
 
     # Example 5: Test multiple accepted encodings
     with haberdasher_connecpy.HaberdasherClientSync(
-        server_url,
-        timeout_ms=timeout_ms,
-        send_compression="br",
+        server_url, timeout_ms=timeout_ms, send_compression="br"
     ) as client:
         try:
             print("\nTesting POST with multiple accepted encodings...")
-            response = client.make_hat(
-                request=create_large_request(),
-            )
+            response = client.make_hat(request=create_large_request())
             print("POST with multiple encodings successful:", response)
         except ConnecpyException as e:
             print("POST with multiple encodings failed:", str(e))

--- a/example/example/flask_mount.py
+++ b/example/example/flask_mount.py
@@ -15,10 +15,7 @@ def health():
 
 
 app.wsgi_app = DispatcherMiddleware(
-    app.wsgi_app,
-    {
-        haberdasher_app.path: haberdasher_app,
-    },
+    app.wsgi_app, {haberdasher_app.path: haberdasher_app}
 )
 
 if __name__ == "__main__":

--- a/example/example/haberdasher_edition_2023_connecpy.py
+++ b/example/example/haberdasher_edition_2023_connecpy.py
@@ -48,7 +48,7 @@ class HaberdasherASGIApplication(ConnecpyASGIApplication):
                         idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
                     ),
                     function=service.make_hat,
-                ),
+                )
             },
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
@@ -111,7 +111,7 @@ class HaberdasherWSGIApplication(ConnecpyWSGIApplication):
                         idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS,
                     ),
                     function=service.make_hat,
-                ),
+                )
             },
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,

--- a/example/example/routing_asgi.py
+++ b/example/example/routing_asgi.py
@@ -21,14 +21,8 @@ def strip_prefix(prefix: str, app: ASGIApp) -> ASGIApp:
 
 app = Starlette(
     routes=[
-        Route(
-            "/healthz",
-            lambda _: PlainTextResponse("OK"),
-        ),
-        Mount(
-            "/services",
-            app=cast("ASGIApp", haberdasher_app),
-        ),
+        Route("/healthz", lambda _: PlainTextResponse("OK")),
+        Mount("/services", app=cast("ASGIApp", haberdasher_app)),
         Mount(
             "/moreservices",
             app=Mount(
@@ -36,9 +30,6 @@ app = Starlette(
                 app=strip_prefix("/moreservices", cast("ASGIApp", haberdasher_app)),
             ),
         ),
-        Mount(
-            haberdasher_app.path,
-            app=cast("ASGIApp", haberdasher_app),
-        ),
+        Mount(haberdasher_app.path, app=cast("ASGIApp", haberdasher_app)),
     ]
 )

--- a/example/example/server.py
+++ b/example/example/server.py
@@ -28,6 +28,5 @@ my_interceptor_a = MyInterceptor("A")
 my_interceptor_b = MyInterceptor("B")
 
 app = haberdasher_connecpy.HaberdasherASGIApplication(
-    HaberdasherService(),
-    interceptors=(my_interceptor_a, my_interceptor_b),
+    HaberdasherService(), interceptors=(my_interceptor_a, my_interceptor_b)
 )

--- a/example/example/starlette_mount.py
+++ b/example/example/starlette_mount.py
@@ -13,15 +13,8 @@ from .server import app as server_app
 
 app = Starlette(
     routes=[
-        Route(
-            "/healthz",
-            lambda _: PlainTextResponse("OK"),
-        ),
-        Mount(
-            "/",
-            app=cast("ASGIApp", server_app),
-            name="haberdasher",
-        ),
+        Route("/healthz", lambda _: PlainTextResponse("OK")),
+        Mount("/", app=cast("ASGIApp", server_app), name="haberdasher"),
     ],
     middleware=[
         Middleware(
@@ -34,6 +27,6 @@ app = Starlette(
                 "Connect-Timeout-Ms",
                 "X-User-Agent",
             ],
-        ),
+        )
     ],
 )

--- a/noextras/test/test_compression_default.py
+++ b/noextras/test/test_compression_default.py
@@ -8,12 +8,7 @@ from example.haberdasher_connecpy import (
     HaberdasherWSGIApplication,
 )
 from example.haberdasher_pb2 import Hat, Size
-from httpx import (
-    ASGITransport,
-    AsyncClient,
-    Client,
-    WSGITransport,
-)
+from httpx import ASGITransport, AsyncClient, Client, WSGITransport
 
 
 @pytest.mark.parametrize("compression", ["gzip", "identity", None])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ build-backend = "uv_build"
 [tool.pytest.ini_options]
 testpaths = ["test"]
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+docstring-code-format = true
+
 [tool.ruff.lint]
 extend-select = [
     # Same order as listed on https://docs.astral.sh/ruff/rules/
@@ -157,6 +161,9 @@ extend-ignore = [
     "PERF",
     "D",
 ]
+
+[tool.ruff.lint.isort]
+split-on-trailing-comma = false
 
 [tool.ruff]
 # Don't run ruff on generated code from external plugins.

--- a/src/connecpy/_client_async.py
+++ b/src/connecpy/_client_async.py
@@ -2,11 +2,7 @@ import asyncio
 import functools
 from asyncio import CancelledError, sleep, wait_for
 from collections.abc import AsyncIterator, Iterable, Mapping
-from typing import (
-    Any,
-    Protocol,
-    TypeVar,
-)
+from typing import Any, Protocol, TypeVar
 
 import httpx
 from httpx import USE_CLIENT_DEFAULT, Timeout
@@ -259,10 +255,7 @@ class ConnecpyClient:
                 request_headers.pop("content-type", None)
                 resp = await wait_for(
                     self._session.get(
-                        url=url,
-                        headers=request_headers,
-                        params=params,
-                        timeout=timeout,
+                        url=url, headers=request_headers, params=params, timeout=timeout
                     ),
                     timeout_s,
                 )
@@ -311,25 +304,19 @@ class ConnecpyClient:
             raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
     async def _send_request_client_stream(
-        self,
-        request: AsyncIterator[REQ],
-        ctx: RequestContext[REQ, RES],
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
     ) -> RES:
         return await _consume_single_response(
             self._send_request_bidi_stream(request, ctx)
         )
 
     def _send_request_server_stream(
-        self,
-        request: REQ,
-        ctx: RequestContext[REQ, RES],
+        self, request: REQ, ctx: RequestContext[REQ, RES]
     ) -> AsyncIterator[RES]:
         return self._send_request_bidi_stream(_yield_single_message(request), ctx)
 
     async def _send_request_bidi_stream(
-        self,
-        request: AsyncIterator[REQ],
-        ctx: RequestContext[REQ, RES],
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
     ) -> AsyncIterator[RES]:
         request_headers = httpx.Headers(list(ctx.request_headers().allitems()))
         url = f"{self._address}/{ctx.method().service_name}/{ctx.method().name}"
@@ -359,8 +346,7 @@ class ConnecpyClient:
                 resp.headers.get(CONNECT_STREAMING_HEADER_COMPRESSION, "")
             )
             _client_shared.validate_stream_response_content_type(
-                self._codec.name(),
-                resp.headers.get("content-type", ""),
+                self._codec.name(), resp.headers.get("content-type", "")
             )
             _client_shared.handle_response_headers(resp.headers)
 
@@ -400,9 +386,7 @@ def _convert_connect_timeout(timeout_ms: float | None) -> Timeout:
 
 
 async def _streaming_request_content(
-    msgs: AsyncIterator[Any],
-    codec: Codec,
-    compression: Compression | None,
+    msgs: AsyncIterator[Any], codec: Codec, compression: Compression | None
 ) -> AsyncIterator[bytes]:
     writer = EnvelopeWriter(codec, compression)
     async for msg in msgs:

--- a/src/connecpy/_client_shared.py
+++ b/src/connecpy/_client_shared.py
@@ -152,9 +152,7 @@ def validate_response_content_encoding(
 
 
 def validate_response_content_type(
-    request_codec_name: str,
-    status_code: int,
-    response_content_type: str,
+    request_codec_name: str, status_code: int, response_content_type: str
 ):
     if status_code != HTTPStatus.OK:
         # Error responses must be JSON-encoded
@@ -194,8 +192,7 @@ def validate_response_content_type(
 
 
 def validate_stream_response_content_type(
-    request_codec_name: str,
-    response_content_type: str,
+    request_codec_name: str, response_content_type: str
 ):
     if not response_content_type.startswith(CONNECT_STREAMING_CONTENT_TYPE_PREFIX):
         raise ConnecpyException(

--- a/src/connecpy/_client_sync.py
+++ b/src/connecpy/_client_sync.py
@@ -1,10 +1,6 @@
 import functools
 from collections.abc import Iterable, Iterator, Mapping
-from typing import (
-    Any,
-    Protocol,
-    TypeVar,
-)
+from typing import Any, Protocol, TypeVar
 
 import httpx
 from httpx import USE_CLIENT_DEFAULT, Timeout
@@ -258,10 +254,7 @@ class ConnecpyClientSync:
                 )
                 request_headers.pop("content-type", None)
                 resp = self._session.get(
-                    url=url,
-                    headers=request_headers,
-                    params=params,
-                    timeout=timeout,
+                    url=url, headers=request_headers, params=params, timeout=timeout
                 )
             else:
                 resp = self._session.post(
@@ -303,23 +296,17 @@ class ConnecpyClientSync:
             raise ConnecpyException(Code.UNAVAILABLE, str(e)) from e
 
     def _send_request_client_stream(
-        self,
-        request: Iterator[REQ],
-        ctx: RequestContext[REQ, RES],
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
     ) -> RES:
         return _consume_single_response(self._send_request_bidi_stream(request, ctx))
 
     def _send_request_server_stream(
-        self,
-        request: REQ,
-        ctx: RequestContext[REQ, RES],
+        self, request: REQ, ctx: RequestContext[REQ, RES]
     ) -> Iterator[RES]:
         return self._send_request_bidi_stream(iter([request]), ctx)
 
     def _send_request_bidi_stream(
-        self,
-        request: Iterator[REQ],
-        ctx: RequestContext[REQ, RES],
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
     ) -> Iterator[RES]:
         request_headers = httpx.Headers(list(ctx.request_headers().allitems()))
         url = f"{self._address}/{ctx.method().service_name}/{ctx.method().name}"
@@ -334,18 +321,14 @@ class ConnecpyClientSync:
             )
 
             resp = self._session.post(
-                url=url,
-                headers=request_headers,
-                content=request_data,
-                timeout=timeout,
+                url=url, headers=request_headers, content=request_data, timeout=timeout
             )
 
             compression = _client_shared.validate_response_content_encoding(
                 resp.headers.get(CONNECT_STREAMING_HEADER_COMPRESSION, "")
             )
             _client_shared.validate_stream_response_content_type(
-                self._codec.name(),
-                resp.headers.get("content-type", ""),
+                self._codec.name(), resp.headers.get("content-type", "")
             )
             _client_shared.handle_response_headers(resp.headers)
 
@@ -380,9 +363,7 @@ def _convert_connect_timeout(timeout_ms: float | None) -> Timeout:
 
 
 def _streaming_request_content(
-    msgs: Iterator[Any],
-    codec: Codec,
-    compression: Compression | None,
+    msgs: Iterator[Any], codec: Codec, compression: Compression | None
 ) -> Iterator[bytes]:
     writer = EnvelopeWriter(codec, compression)
     for msg in msgs:

--- a/src/connecpy/_compression.py
+++ b/src/connecpy/_compression.py
@@ -164,9 +164,7 @@ def parse_accept_encoding(accept_encoding: str | bytes) -> list[tuple[str, float
 
 
 # TODO: wrong sorting order, use preference order instead of available order
-def select_encoding(
-    accept_encoding: str | bytes,
-) -> str:
+def select_encoding(accept_encoding: str | bytes) -> str:
     """Select the best compression encoding based on Accept-Encoding header.
 
     Args:

--- a/src/connecpy/_interceptor_async.py
+++ b/src/connecpy/_interceptor_async.py
@@ -1,10 +1,5 @@
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
-from typing import (
-    Generic,
-    Protocol,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import Generic, Protocol, TypeVar, runtime_checkable
 
 from .request import RequestContext
 

--- a/src/connecpy/_interceptor_sync.py
+++ b/src/connecpy/_interceptor_sync.py
@@ -1,10 +1,5 @@
 from collections.abc import Callable, Iterable, Iterator, Sequence
-from typing import (
-    Generic,
-    Protocol,
-    TypeVar,
-    runtime_checkable,
-)
+from typing import Generic, Protocol, TypeVar, runtime_checkable
 
 from .request import RequestContext
 

--- a/src/connecpy/_protocol.py
+++ b/src/connecpy/_protocol.py
@@ -152,10 +152,7 @@ class ConnectWireError:
         return _error_to_http_status.get(self.code, _INTERNAL_SERVER_ERROR)
 
     def to_dict(self) -> dict:
-        data: dict = {
-            "code": self.code.value,
-            "message": self.message,
-        }
+        data: dict = {"code": self.code.value, "message": self.message}
         if self.details:
             details: list[dict[str, str]] = []
             for detail in self.details:

--- a/src/connecpy/_server_shared.py
+++ b/src/connecpy/_server_shared.py
@@ -1,10 +1,7 @@
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from http import HTTPStatus
-from typing import (
-    Generic,
-    TypeVar,
-)
+from typing import Generic, TypeVar
 
 from ._protocol import (
     CONNECT_HEADER_PROTOCOL_VERSION,
@@ -43,97 +40,51 @@ class Endpoint(Generic[REQ, RES]):
     @staticmethod
     def unary(
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                T,
-                RequestContext[T, U],
-            ],
-            Awaitable[U],
-        ],
+        function: Callable[[T, RequestContext[T, U]], Awaitable[U]],
     ) -> "Endpoint[T, U]":
         return EndpointUnary(method=method, function=function)
 
     @staticmethod
     def client_stream(
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                AsyncIterator[T],
-                RequestContext[T, U],
-            ],
-            Awaitable[U],
-        ],
+        function: Callable[[AsyncIterator[T], RequestContext[T, U]], Awaitable[U]],
     ) -> "Endpoint[T, U]":
         return EndpointClientStream(method=method, function=function)
 
     @staticmethod
     def server_stream(
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                T,
-                RequestContext[T, U],
-            ],
-            AsyncIterator[U],
-        ],
+        function: Callable[[T, RequestContext[T, U]], AsyncIterator[U]],
     ) -> "Endpoint[T, U]":
         return EndpointServerStream(method=method, function=function)
 
     @staticmethod
     def bidi_stream(
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                AsyncIterator[T],
-                RequestContext[T, U],
-            ],
-            AsyncIterator[U],
-        ],
+        function: Callable[[AsyncIterator[T], RequestContext[T, U]], AsyncIterator[U]],
     ) -> "Endpoint[T, U]":
         return EndpointBidiStream(method=method, function=function)
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointUnary(Endpoint[REQ, RES]):
-    function: Callable[
-        [
-            REQ,
-            RequestContext[REQ, RES],
-        ],
-        Awaitable[RES],
-    ]
+    function: Callable[[REQ, RequestContext[REQ, RES]], Awaitable[RES]]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointClientStream(Endpoint[REQ, RES]):
-    function: Callable[
-        [
-            AsyncIterator[REQ],
-            RequestContext[REQ, RES],
-        ],
-        Awaitable[RES],
-    ]
+    function: Callable[[AsyncIterator[REQ], RequestContext[REQ, RES]], Awaitable[RES]]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointServerStream(Endpoint[REQ, RES]):
-    function: Callable[
-        [
-            REQ,
-            RequestContext[REQ, RES],
-        ],
-        AsyncIterator[RES],
-    ]
+    function: Callable[[REQ, RequestContext[REQ, RES]], AsyncIterator[RES]]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointBidiStream(Endpoint[REQ, RES]):
     function: Callable[
-        [
-            AsyncIterator[REQ],
-            RequestContext[REQ, RES],
-        ],
-        AsyncIterator[RES],
+        [AsyncIterator[REQ], RequestContext[REQ, RES]], AsyncIterator[RES]
     ]
 
 
@@ -156,15 +107,7 @@ class EndpointSync(Generic[REQ, RES]):
 
     @staticmethod
     def unary(
-        *,
-        method: MethodInfo[T, U],
-        function: Callable[
-            [
-                T,
-                RequestContext[T, U],
-            ],
-            U,
-        ],
+        *, method: MethodInfo[T, U], function: Callable[[T, RequestContext[T, U]], U]
     ) -> "EndpointSync[T, U]":
         return EndpointUnarySync(method=method, function=function)
 
@@ -172,13 +115,7 @@ class EndpointSync(Generic[REQ, RES]):
     def client_stream(
         *,
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                Iterator[T],
-                RequestContext[T, U],
-            ],
-            U,
-        ],
+        function: Callable[[Iterator[T], RequestContext[T, U]], U],
     ) -> "EndpointSync[T, U]":
         return EndpointClientStreamSync(method=method, function=function)
 
@@ -186,72 +123,36 @@ class EndpointSync(Generic[REQ, RES]):
     def server_stream(
         *,
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                T,
-                RequestContext[T, U],
-            ],
-            Iterator[U],
-        ],
+        function: Callable[[T, RequestContext[T, U]], Iterator[U]],
     ) -> "EndpointSync[T, U]":
         return EndpointServerStreamSync(method=method, function=function)
 
     @staticmethod
     def bidi_stream(
         method: MethodInfo[T, U],
-        function: Callable[
-            [
-                Iterator[T],
-                RequestContext[T, U],
-            ],
-            Iterator[U],
-        ],
+        function: Callable[[Iterator[T], RequestContext[T, U]], Iterator[U]],
     ) -> "EndpointSync[T, U]":
         return EndpointBidiStreamSync(method=method, function=function)
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointUnarySync(EndpointSync[REQ, RES]):
-    function: Callable[
-        [
-            REQ,
-            RequestContext[REQ, RES],
-        ],
-        RES,
-    ]
+    function: Callable[[REQ, RequestContext[REQ, RES]], RES]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointClientStreamSync(EndpointSync[REQ, RES]):
-    function: Callable[
-        [
-            Iterator[REQ],
-            RequestContext[REQ, RES],
-        ],
-        RES,
-    ]
+    function: Callable[[Iterator[REQ], RequestContext[REQ, RES]], RES]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointServerStreamSync(EndpointSync[REQ, RES]):
-    function: Callable[
-        [
-            REQ,
-            RequestContext[REQ, RES],
-        ],
-        Iterator[RES],
-    ]
+    function: Callable[[REQ, RequestContext[REQ, RES]], Iterator[RES]]
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class EndpointBidiStreamSync(EndpointSync[REQ, RES]):
-    function: Callable[
-        [
-            Iterator[REQ],
-            RequestContext[REQ, RES],
-        ],
-        Iterator[RES],
-    ]
+    function: Callable[[Iterator[REQ], RequestContext[REQ, RES]], Iterator[RES]]
 
 
 def create_request_context(
@@ -259,15 +160,9 @@ def create_request_context(
 ) -> RequestContext[REQ, RES]:
     if method.idempotency_level == IdempotencyLevel.NO_SIDE_EFFECTS:
         if http_method not in ("GET", "POST"):
-            raise HTTPException(
-                HTTPStatus.METHOD_NOT_ALLOWED,
-                [("allow", "GET, POST")],
-            )
+            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, [("allow", "GET, POST")])
     elif http_method != "POST":
-        raise HTTPException(
-            HTTPStatus.METHOD_NOT_ALLOWED,
-            [("allow", "POST")],
-        )
+        raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, [("allow", "POST")])
 
     # We don't require connect-protocol-version header. connect-go provides an option
     # to require it but it's almost never used in practice.
@@ -291,8 +186,7 @@ def create_request_context(
             timeout_ms = int(timeout_header)
         except ValueError as e:
             raise ConnecpyException(
-                Code.INVALID_ARGUMENT,
-                f"Invalid timeout header: '{timeout_header}'",
+                Code.INVALID_ARGUMENT, f"Invalid timeout header: '{timeout_header}'"
             ) from e
     else:
         timeout_ms = None
@@ -307,13 +201,7 @@ def create_request_context(
 def verify_http_method(http_method: str, method: MethodInfo) -> None:
     if method.idempotency_level == IdempotencyLevel.NO_SIDE_EFFECTS:
         if http_method not in ("GET", "POST"):
-            raise HTTPException(
-                HTTPStatus.METHOD_NOT_ALLOWED,
-                [("allow", "GET, POST")],
-            )
+            raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, [("allow", "GET, POST")])
         return
     if http_method != "POST":
-        raise HTTPException(
-            HTTPStatus.METHOD_NOT_ALLOWED,
-            [("allow", "POST")],
-        )
+        raise HTTPException(HTTPStatus.METHOD_NOT_ALLOWED, [("allow", "POST")])

--- a/src/connecpy/_server_sync.py
+++ b/src/connecpy/_server_sync.py
@@ -4,10 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import replace
 from http import HTTPStatus
-from typing import (
-    TYPE_CHECKING,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, TypeVar
 from urllib.parse import parse_qs
 
 from . import _compression, _server_shared
@@ -447,10 +444,7 @@ class ConnecpyWSGIApplication(ABC):
                 start_response, codec, response_compression_name, ctx
             )
             return [
-                writer.end(
-                    ctx.response_trailers(),
-                    ConnectWireError.from_exception(e),
-                )
+                writer.end(ctx.response_trailers(), ConnectWireError.from_exception(e))
             ]
 
     def _handle_error(self, exc, ctx: RequestContext | None, _environ, start_response):
@@ -490,14 +484,8 @@ def _send_stream_response_headers(
     ctx: RequestContext,
 ):
     response_headers = [
-        (
-            "content-type",
-            f"{CONNECT_STREAMING_CONTENT_TYPE_PREFIX}{codec.name()}",
-        ),
-        (
-            CONNECT_STREAMING_HEADER_COMPRESSION,
-            compression_name,
-        ),
+        ("content-type", f"{CONNECT_STREAMING_CONTENT_TYPE_PREFIX}{codec.name()}"),
+        (CONNECT_STREAMING_HEADER_COMPRESSION, compression_name),
     ]
     response_headers.extend(
         (key, value) for key, value in ctx.response_headers().allitems()

--- a/src/connecpy/client.py
+++ b/src/connecpy/client.py
@@ -1,8 +1,4 @@
-__all__ = [
-    "ConnecpyClient",
-    "ConnecpyClientSync",
-    "ResponseMetadata",
-]
+__all__ = ["ConnecpyClient", "ConnecpyClientSync", "ResponseMetadata"]
 
 
 from ._client_async import ConnecpyClient

--- a/src/connecpy/method.py
+++ b/src/connecpy/method.py
@@ -1,7 +1,4 @@
-__all__ = [
-    "IdempotencyLevel",
-    "MethodInfo",
-]
+__all__ = ["IdempotencyLevel", "MethodInfo"]
 
 
 import enum

--- a/src/connecpy/server.py
+++ b/src/connecpy/server.py
@@ -7,8 +7,5 @@ __all__ = [
 
 
 from ._server_async import ConnecpyASGIApplication
-from ._server_shared import (
-    Endpoint,
-    EndpointSync,
-)
+from ._server_shared import Endpoint, EndpointSync
 from ._server_sync import ConnecpyWSGIApplication

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,10 +1,5 @@
 import pytest
-from httpx import (
-    ASGITransport,
-    AsyncClient,
-    Client,
-    WSGITransport,
-)
+from httpx import ASGITransport, AsyncClient, Client, WSGITransport
 
 from connecpy.client import ResponseMetadata
 from example.haberdasher_connecpy import (

--- a/test/test_details.py
+++ b/test/test_details.py
@@ -1,12 +1,7 @@
 import pytest
 from google.protobuf.any import pack
 from google.protobuf.struct_pb2 import Struct, Value
-from httpx import (
-    ASGITransport,
-    AsyncClient,
-    Client,
-    WSGITransport,
-)
+from httpx import ASGITransport, AsyncClient, Client, WSGITransport
 
 from connecpy.code import Code
 from connecpy.exceptions import ConnecpyException

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -48,11 +48,7 @@ _errors = [
 
 
 @pytest.mark.parametrize(("code", "message", "http_status"), _errors)
-def test_sync_errors(
-    code: Code,
-    message: str,
-    http_status: int,
-):
+def test_sync_errors(code: Code, message: str, http_status: int):
     class ErrorHaberdasherSync(HaberdasherSync):
         def __init__(self, exception: ConnecpyException):
             self._exception = exception
@@ -86,11 +82,7 @@ def test_sync_errors(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(("code", "message", "http_status"), _errors)
-async def test_async_errors(
-    code: Code,
-    message: str,
-    http_status: int,
-):
+async def test_async_errors(code: Code, message: str, http_status: int):
     class ErrorHaberdasher(Haberdasher):
         def __init__(self, exception: ConnecpyException):
             self._exception = exception
@@ -155,11 +147,7 @@ _http_errors = [
         id="connect error without message",
     ),
     pytest.param(
-        502,
-        {"text": '"{bad_json'},
-        Code.UNAVAILABLE,
-        "Bad Gateway",
-        id="bad json",
+        502, {"text": '"{bad_json'}, Code.UNAVAILABLE, "Bad Gateway", id="bad json"
     ),
     pytest.param(
         200,
@@ -276,10 +264,7 @@ def test_sync_client_errors(
 
     client = Client(transport=transport)
     response = client.request(
-        method=method,
-        url=f"http://localhost{path}",
-        content=body,
-        headers=headers,
+        method=method, url=f"http://localhost{path}", content=body, headers=headers
     )
 
     assert response.status_code == response_status
@@ -304,10 +289,7 @@ async def test_async_client_errors(
 
     client = AsyncClient(transport=transport)
     response = await client.request(
-        method=method,
-        url=f"http://localhost{path}",
-        content=body,
-        headers=headers,
+        method=method, url=f"http://localhost{path}", content=body, headers=headers
     )
 
     assert response.status_code == response_status
@@ -337,11 +319,7 @@ def sync_timeout_server():
 
 
 @pytest.mark.parametrize(
-    ("client_timeout_ms", "call_timeout_ms"),
-    [
-        (1, None),
-        (None, 1),
-    ],
+    ("client_timeout_ms", "call_timeout_ms"), [(1, None), (None, 1)]
 )
 def test_sync_client_timeout(
     client_timeout_ms, call_timeout_ms, sync_timeout_server: WSGIServer
@@ -380,11 +358,7 @@ def test_sync_client_timeout(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("client_timeout_ms", "call_timeout_ms"),
-    [
-        (1, None),
-        (None, 1),
-    ],
+    ("client_timeout_ms", "call_timeout_ms"), [(1, None), (None, 1)]
 )
 async def test_async_client_timeout(
     client_timeout_ms, call_timeout_ms, sync_timeout_server: WSGIServer

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -70,10 +70,7 @@ def test_headers_duplicates():
     assert h.getall("x-test") == ["foo", "bar", "baz"]
     h["authorization"] = "cookie"
     assert h["authorization"] == "cookie"
-    assert list(h.items()) == [
-        ("x-test", "foo"),
-        ("authorization", "cookie"),
-    ]
+    assert list(h.items()) == [("x-test", "foo"), ("authorization", "cookie")]
     assert list(h.keys()) == ["x-test", "authorization"]
     assert list(h.values()) == ["foo", "cookie"]
     assert list(h.allitems()) == [
@@ -87,21 +84,13 @@ def test_headers_duplicates():
     assert len(h) == 1
     h["x-Test"] = "again"
     assert h["x-test"] == "again"
-    assert list(h.allitems()) == [
-        ("authorization", "cookie"),
-        ("x-test", "again"),
-    ]
+    assert list(h.allitems()) == [("authorization", "cookie"), ("x-test", "again")]
     h.add("x-test", "and again")
     # Implemented by base class using dunder methods
     h.pop("x-test", None)
-    assert list(h.allitems()) == [
-        ("authorization", "cookie"),
-    ]
+    assert list(h.allitems()) == [("authorization", "cookie")]
     h.add("x-animal", "bear")
     h.add("x-animal", "cat")
     h.update({"x-animal": "dog"})
-    assert list(h.allitems()) == [
-        ("authorization", "cookie"),
-        ("x-animal", "dog"),
-    ]
+    assert list(h.allitems()) == [("authorization", "cookie"), ("x-animal", "dog")]
     assert h.getall("x-animal") == ["dog"]

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -1,12 +1,7 @@
 from collections.abc import AsyncIterator, Iterator
 
 import pytest
-from httpx import (
-    ASGITransport,
-    AsyncClient,
-    Client,
-    WSGITransport,
-)
+from httpx import ASGITransport, AsyncClient, Client, WSGITransport
 
 from connecpy.code import Code
 from connecpy.exceptions import ConnecpyException
@@ -101,10 +96,7 @@ async def test_roundtrip_response_stream_async(proto_json: bool, compression: st
 
 @pytest.mark.parametrize("client_bad", [False, True])
 @pytest.mark.parametrize("compression", ["gzip", "br", "zstd", "identity"])
-def test_message_limit_sync(
-    client_bad: bool,
-    compression: str,
-):
+def test_message_limit_sync(client_bad: bool, compression: str):
     requests: list[Size] = []
     responses: list[Hat] = []
 
@@ -167,10 +159,7 @@ def test_message_limit_sync(
 @pytest.mark.parametrize("client_bad", [False, True])
 @pytest.mark.parametrize("compression", ["gzip", "br", "zstd", "identity"])
 @pytest.mark.asyncio
-async def test_message_limit_async(
-    client_bad: bool,
-    compression: str,
-):
+async def test_message_limit_async(client_bad: bool, compression: str):
     requests: list[Size] = []
     responses: list[Hat] = []
 


### PR DESCRIPTION
By default, ruff follows Black's decision of never reformating code with trailing commas even if it can be compacted. This defers from other popular formatters like prettier which prioritize having just _one_ way of formatting any type of code. In practice, I think the latter is a better approach for consistency, as I see extra line breaks due to trailing commas be more accidental than not in most cases. In rare cases when really needing it, often it's appropriate to add a `# ` comment or similar.