### PR TITLE
chore: simplify compression negotiation

### DIFF
--- a/src/connecpy/_compression.py
+++ b/src/connecpy/_compression.py
@@ -100,7 +100,8 @@ class IdentityCompression(Compression):
         return True
 
 
-_compressions["identity"] = IdentityCompression()
+_identity = IdentityCompression()
+_compressions["identity"] = _identity
 
 
 def get_compression(name: str) -> Compression | None:
@@ -112,96 +113,9 @@ def get_available_compressions() -> KeysView:
     return _compressions.keys()
 
 
-def parse_accept_encoding(accept_encoding: str | bytes) -> list[tuple[str, float]]:
-    """Parse Accept-Encoding header value with quality values.
-
-    Args:
-        accept_encoding: The Accept-Encoding header value (str or bytes)
-
-    Returns:
-        list[tuple[str, float]]: List of (encoding, q-value) pairs, sorted by q-value
-    """
-    if not accept_encoding:
-        return [("identity", 1.0)]
-
-    # Convert bytes to string if needed
-    if isinstance(accept_encoding, bytes):
-        accept_encoding = accept_encoding.decode("ascii")
-
-    encodings = []
-    seen = set()  # Track seen encodings to avoid duplicates
-
-    # First, handle special case of "identity;q=0,*;q=0" which means "no encoding allowed"
-    if accept_encoding.replace(" ", "") == "identity;q=0,*;q=0":
-        return [("identity", 0.0), ("*", 0.0)]
-
-    for p in accept_encoding.split(","):
-        part = p.strip()
-        if not part:
-            continue
-
-        # Split encoding and q-value
-        if ";" in part:
-            encoding, q_part = part.split(";", 1)
-            encoding = encoding.strip().lower()
-            try:
-                if not q_part.strip().lower().startswith("q="):
-                    continue
-                q = float(q_part.strip().lower().replace("q=", ""))
-                q = max(0.0, min(1.0, q))  # Clamp between 0 and 1
-            except (ValueError, AttributeError):
-                q = 1.0
-        else:
-            encoding = part.strip().lower()
-            q = 1.0
-
-        if encoding and encoding not in seen:
-            seen.add(encoding)
-            encodings.append((encoding, q))
-
-    # Sort by q-value in descending order while preserving the original accept-encoding order for equal q-values
-    return sorted(encodings, key=lambda x: -x[1])
-
-
-# TODO: wrong sorting order, use preference order instead of available order
-def select_encoding(
-    accept_encoding: str | bytes,
-) -> str:
-    """Select the best compression encoding based on Accept-Encoding header.
-
-    Args:
-        accept_encoding: The Accept-Encoding header value (str or bytes)
-        available_encodings: Tuple of available encodings.
-            Defaults to ("br", "gzip", "zstd", "identity")
-
-    Returns:
-        str: The selected encoding name
-    """
-    # Parse Accept-Encoding header with q-values (already sorted by q descending)
-    encodings = parse_accept_encoding(accept_encoding)
-
-    # Check for "no encoding allowed" case
-    if (
-        len(encodings) == 2
-        and all(q == 0.0 for _, q in encodings)
-        and {"identity", "*"} == {enc for enc, _ in encodings}
-    ):
-        return "identity"
-
-    # Iterate over client-preferred encodings (sorted by q-value)
-    for client_encoding, q in encodings:
-        if q <= 0:
-            continue
-        if client_encoding == "*":
-            # For wildcard, choose any available encoding not explicitly defined by the client.
-            excluded = {enc for enc, _ in encodings if enc != "*"}
-            candidates = [enc for enc in _compressions if enc not in excluded]
-            if candidates:
-                return candidates[0]
-            # If all available encodings were explicitly mentioned, return the first available.
-            return next(iter(get_available_compressions()))
-        if client_encoding in _compressions:
-            return client_encoding
-
-    # If no match found, fallback to identity
-    return "identity"
+def negotiate_compression(accept_encoding: str) -> Compression:
+    for accept in accept_encoding.split(","):
+        compression = _compressions.get(accept.strip())
+        if compression:
+            return compression
+    return _identity

--- a/src/connecpy/_server_sync.py
+++ b/src/connecpy/_server_sync.py
@@ -4,10 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import replace
 from http import HTTPStatus
-from typing import (
-    TYPE_CHECKING,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, TypeVar
 from urllib.parse import parse_qs
 
 from . import _compression, _server_shared
@@ -82,10 +79,8 @@ def _process_headers(headers: dict) -> Headers:
 
 
 def prepare_response_headers(
-    base_headers: dict[str, list[str]],
-    selected_encoding: str,
-    compressed_size: int | None = None,
-) -> tuple[dict[str, list[str]], bool]:
+    base_headers: dict[str, list[str]], selected_encoding: str
+) -> dict[str, list[str]]:
     """Prepare response headers and determine if compression should be used.
 
     Args:
@@ -97,17 +92,13 @@ def prepare_response_headers(
         tuple[dict, bool]: Final headers and whether to use compression
     """
     headers = base_headers.copy()
-    use_compression = False
 
     if "content-type" not in headers:
         headers["content-type"] = ["application/proto"]
 
-    if selected_encoding != "identity" and compressed_size is not None:
-        headers["content-encoding"] = [selected_encoding]
-        use_compression = True
-
+    headers["content-encoding"] = [selected_encoding]
     headers["vary"] = ["Accept-Encoding"]
-    return headers, use_compression
+    return headers
 
 
 def _read_body(environ: WSGIEnvironment) -> Iterator[bytes]:
@@ -219,17 +210,9 @@ class ConnecpyWSGIApplication(ABC):
 
         # Handle compression if accepted
         accept_encoding = headers.get("accept-encoding", "identity")
-        selected_encoding = _compression.select_encoding(accept_encoding)
-        compressed_bytes = None
-        if selected_encoding != "identity":
-            compression = _compression.get_compression(selected_encoding)
-            if compression:
-                compressed_bytes = compression.compress(res_bytes)
-        response_headers, use_compression = prepare_response_headers(
-            base_headers,
-            selected_encoding,
-            len(compressed_bytes) if compressed_bytes is not None else None,
-        )
+        compression = _compression.negotiate_compression(accept_encoding)
+        res_bytes = compression.compress(res_bytes)
+        response_headers = prepare_response_headers(base_headers, compression.name())
 
         # Convert headers to WSGI format
         wsgi_headers: list[tuple[str, str]] = []
@@ -239,10 +222,7 @@ class ConnecpyWSGIApplication(ABC):
         _add_context_headers(wsgi_headers, ctx)
 
         start_response("200 OK", wsgi_headers)
-        final_response = (
-            compressed_bytes if use_compression and compressed_bytes else res_bytes
-        )
-        return [final_response]
+        return [res_bytes]
 
     def _handle_post_request(
         self,
@@ -382,8 +362,7 @@ class ConnecpyWSGIApplication(ABC):
         accept_compression = headers.get(
             CONNECT_STREAMING_HEADER_ACCEPT_COMPRESSION, ""
         )
-        response_compression_name = _compression.select_encoding(accept_compression)
-        response_compression = _compression.get_compression(response_compression_name)
+        response_compression = _compression.negotiate_compression(accept_compression)
 
         codec_name = codec_name_from_content_type(
             headers.get("content-type", ""), stream=True
@@ -426,7 +405,7 @@ class ConnecpyWSGIApplication(ABC):
             # Response headers set before the first message should be set to the context and
             # we can send them.
             _send_stream_response_headers(
-                start_response, codec, response_compression_name, ctx
+                start_response, codec, response_compression.name(), ctx
             )
             if first_response is None:
                 # It's valid for a service method to return no messages, finish the response
@@ -444,13 +423,10 @@ class ConnecpyWSGIApplication(ABC):
             # response message will be handled by _response_stream, so here we have a
             # full error-only response.
             _send_stream_response_headers(
-                start_response, codec, response_compression_name, ctx
+                start_response, codec, response_compression.name(), ctx
             )
             return [
-                writer.end(
-                    ctx.response_trailers(),
-                    ConnectWireError.from_exception(e),
-                )
+                writer.end(ctx.response_trailers(), ConnectWireError.from_exception(e))
             ]
 
     def _handle_error(self, exc, ctx: RequestContext | None, _environ, start_response):
@@ -490,14 +466,8 @@ def _send_stream_response_headers(
     ctx: RequestContext,
 ):
     response_headers = [
-        (
-            "content-type",
-            f"{CONNECT_STREAMING_CONTENT_TYPE_PREFIX}{codec.name()}",
-        ),
-        (
-            CONNECT_STREAMING_HEADER_COMPRESSION,
-            compression_name,
-        ),
+        ("content-type", f"{CONNECT_STREAMING_CONTENT_TYPE_PREFIX}{codec.name()}"),
+        (CONNECT_STREAMING_HEADER_COMPRESSION, compression_name),
     ]
     response_headers.extend(
         (key, value) for key, value in ctx.response_headers().allitems()


### PR DESCRIPTION
Currently there are many lines in compression negotiation not covered by tests. But we can just use simplified negotation and remove them. The spec says that clients can't send complex accept-encoding - it also says servers can parse complex accept-encoding, but I think it's only to allow use of built-in compression middleware, if implementing ourselves we may as well use the simple one, since clients will always send the simple one.

I did try sending a PR to clarify it though no response

https://github.com/connectrpc/connectrpc.com/pull/283

For context, connect-go parses simple, for above reason I think

https://github.com/connectrpc/connect-go/blob/main/protocol.go#L332