### PR TITLE
feat: add option for generating relative imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ protoc --python_out=./ --pyi_out=./ --connecpy_out=./ ./haberdasher.proto
 ```
 
 By default, naming follows PEP8 conventions. To use Google conventions, matching the output of grpc-python, add `--connecpy_opt=naming=google`.
+By default, imports are generated absolutely based on the proto package name. To use relative import, add `--connecpy_opt=imports=relative`.
 
 ### Server code (ASGI)
 

--- a/example/buf.gen.yaml
+++ b/example/buf.gen.yaml
@@ -5,3 +5,5 @@ plugins:
       - run
       - ../protoc-gen-connecpy
     out: .
+    opt:
+      - imports=relative

--- a/example/example/haberdasher_connecpy.py
+++ b/example/example/haberdasher_connecpy.py
@@ -18,7 +18,7 @@ from connecpy.server import (
     EndpointSync,
 )
 
-import example.haberdasher_pb2 as example_dot_haberdasher__pb2
+from . import haberdasher_pb2 as example_dot_haberdasher__pb2
 
 
 class Haberdasher(Protocol):

--- a/example/example/haberdasher_edition_2023_connecpy.py
+++ b/example/example/haberdasher_edition_2023_connecpy.py
@@ -17,7 +17,9 @@ from connecpy.server import (
     EndpointSync,
 )
 
-import example.haberdasher_edition_2023_pb2 as example_dot_haberdasher__edition__2023__pb2
+from . import (
+    haberdasher_edition_2023_pb2 as example_dot_haberdasher__edition__2023__pb2,
+)
 
 
 class Haberdasher(Protocol):

--- a/protoc-gen-connecpy/generator/config.go
+++ b/protoc-gen-connecpy/generator/config.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// Naming is the naming convention to use for generated symbols.
 type Naming uint32
 
 const (
@@ -15,10 +16,24 @@ const (
 	NamingGoogle
 )
 
+// Imports is how to import dependencies in the generated code.
+type Imports uint32
+
+const (
+	// ImportsAbsolute uses absolute imports following the proto's package definition.
+	ImportsAbsolute Imports = iota
+
+	// ImportsRelative uses relative imports.
+	ImportsRelative
+)
+
 // Config is the configuration for code generation.
 type Config struct {
 	// Naming is the naming convention to use for generated symbols.
 	Naming Naming
+
+	// Imports is how to import dependencies in the generated code.
+	Imports Imports
 }
 
 func parseConfig(p string) Config {
@@ -41,6 +56,13 @@ func parseConfig(p string) Config {
 				cfg.Naming = NamingPEP
 			case "google":
 				cfg.Naming = NamingGoogle
+			}
+		case "imports":
+			switch value {
+			case "absolute":
+				cfg.Imports = ImportsAbsolute
+			case "relative":
+				cfg.Imports = ImportsRelative
 			}
 		}
 	}

--- a/protoc-gen-connecpy/generator/generator.go
+++ b/protoc-gen-connecpy/generator/generator.go
@@ -69,7 +69,7 @@ func GenerateConnecpyFile(fd protoreflect.FileDescriptor, conf Config) (*plugin.
 	vars := ConnecpyTemplateVariables{
 		FileName:   filename,
 		ModuleName: moduleName,
-		Imports:    importStatements(fd),
+		Imports:    importStatements(fd, conf),
 	}
 
 	svcs := fd.Services()
@@ -189,26 +189,47 @@ func symbolName(msg protoreflect.MessageDescriptor) string {
 	return fmt.Sprintf("%s.%s", moduleAlias(filename), name)
 }
 
-func importStatements(file protoreflect.FileDescriptor) []ImportStatement {
-	mods := map[string]string{}
+func lastPart(imp string) string {
+	if dotIdx := strings.LastIndexByte(imp, '.'); dotIdx != -1 {
+		return imp[dotIdx+1:]
+	}
+	return imp
+}
+
+func generateImport(pkg string, conf Config, isLocal bool) (string, ImportStatement) {
+	name := moduleName(pkg)
+	imp := ImportStatement{
+		Name:  name,
+		Alias: moduleAlias(pkg),
+	}
+	if isLocal && conf.Imports == ImportsRelative {
+		name = lastPart(name)
+		imp.Name = name
+		imp.Relative = true
+	}
+	return name, imp
+}
+
+func importStatements(file protoreflect.FileDescriptor, conf Config) []ImportStatement {
+	mods := map[string]ImportStatement{}
 	for i := 0; i < file.Services().Len(); i++ {
 		svc := file.Services().Get(i)
 		for j := 0; j < svc.Methods().Len(); j++ {
 			method := svc.Methods().Get(j)
 			inPkg := string(method.Input().ParentFile().Path())
-			mods[moduleName(inPkg)] = moduleAlias(inPkg)
+			inName, inImp := generateImport(inPkg, conf, method.Input().ParentFile() == file)
+			mods[inName] = inImp
 			outPkg := string(method.Output().ParentFile().Path())
-			mods[moduleName(outPkg)] = moduleAlias(outPkg)
+			outName, outImp := generateImport(outPkg, conf, method.Output().ParentFile() == file)
+			mods[outName] = outImp
 		}
 	}
 
 	imports := make([]ImportStatement, 0, len(mods))
-	for mod, alias := range mods {
-		imports = append(imports, ImportStatement{
-			Name:  mod,
-			Alias: alias,
-		})
+	for _, imp := range mods {
+		imports = append(imports, imp)
 	}
+
 	slices.SortFunc(imports, func(a, b ImportStatement) int {
 		return strings.Compare(a.Name, b.Name)
 	})

--- a/protoc-gen-connecpy/generator/template.go
+++ b/protoc-gen-connecpy/generator/template.go
@@ -3,8 +3,9 @@ package generator
 import "text/template"
 
 type ImportStatement struct {
-	Name  string
-	Alias string
+	Name     string
+	Alias    string
+	Relative bool
 }
 
 type ConnecpyTemplateVariables struct {
@@ -55,7 +56,7 @@ from connecpy.request import Headers, RequestContext
 from connecpy.server import ConnecpyASGIApplication, ConnecpyWSGIApplication, Endpoint, EndpointSync
 
 {{- range .Imports }}
-import {{.Name}} as {{.Alias}}
+{{if .Relative}}from . import {{.Name}}{{else}}import {{.Name}}{{end}} as {{.Alias}}
 {{- end}}
 {{- end}}
 {{- range .Services}}


### PR DESCRIPTION
Absolute imports tend to be more compatible, for example working in a `test` folder, but sometimes relative is easier to use, notably it allows the folder to be relocatable if wanting apps to be able to import using different name than the proto package. This is notably important for python where the protoc plugin provides no option for customizing the packages like Go, Java etc do.

This goes ahead and applies to `example` where it works and leaves conformance where it wouldn't.