### PR TITLE
chore: improve protoc plugin installation using a shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTO
 
 #### Option 2: Manual Download
 
-1. **Download the appropriate binary for your platform** from [GitHub Releases](https://github.com/i2y/connecpy/releases/latest):
-   - **Linux AMD64**: `protoc-gen-connecpy-linux-amd64`
-   - **Linux ARM64**: `protoc-gen-connecpy-linux-arm64`
-   - **macOS Intel**: `protoc-gen-connecpy-darwin-amd64`
-   - **macOS Apple Silicon**: `protoc-gen-connecpy-darwin-arm64`
-   - **Windows AMD64**: `protoc-gen-connecpy-windows-amd64.exe`
-   - **Windows ARM64**: `protoc-gen-connecpy-windows-arm64.exe`
+1. **Download the appropriate archive for your platform** from [GitHub Releases](https://github.com/i2y/connecpy/releases/latest):
+   - **Linux AMD64**: `protoc-gen-connecpy_VERSION_linux_amd64.tar.gz`
+   - **Linux ARM64**: `protoc-gen-connecpy_VERSION_linux_arm64.tar.gz`
+   - **macOS Intel**: `protoc-gen-connecpy_VERSION_darwin_amd64.tar.gz`
+   - **macOS Apple Silicon**: `protoc-gen-connecpy_VERSION_darwin_arm64.tar.gz`
+   - **Windows AMD64**: `protoc-gen-connecpy_VERSION_windows_amd64.zip`
+   - **Windows ARM64**: `protoc-gen-connecpy_VERSION_windows_arm64.zip`
 
-2. **Rename and install the binary:**
+2. **Extract and install the binary:**
 
    **Linux/macOS:**
    ```bash
-   # Rename to protoc-gen-connecpy
-   mv protoc-gen-connecpy-* protoc-gen-connecpy
+   # Extract the archive
+   tar -xzf protoc-gen-connecpy_*.tar.gz
    
-   # Make executable
+   # Make executable (if needed)
    chmod +x protoc-gen-connecpy
    
    # Move to a directory in PATH
@@ -70,8 +70,8 @@ curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTO
 
    **Windows (PowerShell):**
    ```powershell
-   # Rename the file
-   Rename-Item protoc-gen-connecpy-windows-*.exe protoc-gen-connecpy.exe
+   # Extract the archive
+   Expand-Archive protoc-gen-connecpy_*.zip -DestinationPath .
    
    # Move to a directory in PATH, for example:
    Move-Item protoc-gen-connecpy.exe C:\Tools\

--- a/README.md
+++ b/README.md
@@ -19,21 +19,84 @@ This repo contains a protoc plugin that generates sever and client code and a py
 
 You can install the protoc plugin using one of these methods:
 
-#### Option 1: Download pre-built binary (recommended)
+#### Option 1: Quick Install (Linux/macOS) - Recommended
 
-Download the latest release from [GitHub Releases](https://github.com/i2y/connecpy/releases/latest) page. Pre-built binaries are available for:
+Install with a single command:
 
-- Linux (amd64, arm64)
-- macOS (amd64, arm64)
-- Windows (amd64, arm64)
+```bash
+curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | bash
+```
 
-#### Option 2: Install with Go
+You can customize the installation with environment variables:
 
-If you have Go installed, you can install using:
+```bash
+# Install to a custom directory
+curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTOC_GEN_CONNECPY_INSTALL=$HOME/.local/bin bash
+
+# Install a specific version
+curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | VERSION=v2.2.0 bash
+
+# Combine multiple options
+curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTOC_GEN_CONNECPY_INSTALL=$HOME/.local/bin VERSION=v2.2.0 bash
+```
+
+#### Option 2: Manual Download
+
+1. **Download the appropriate binary for your platform** from [GitHub Releases](https://github.com/i2y/connecpy/releases/latest):
+   - **Linux AMD64**: `protoc-gen-connecpy-linux-amd64`
+   - **Linux ARM64**: `protoc-gen-connecpy-linux-arm64`
+   - **macOS Intel**: `protoc-gen-connecpy-darwin-amd64`
+   - **macOS Apple Silicon**: `protoc-gen-connecpy-darwin-arm64`
+   - **Windows AMD64**: `protoc-gen-connecpy-windows-amd64.exe`
+   - **Windows ARM64**: `protoc-gen-connecpy-windows-arm64.exe`
+
+2. **Rename and install the binary:**
+
+   **Linux/macOS:**
+   ```bash
+   # Rename to protoc-gen-connecpy
+   mv protoc-gen-connecpy-* protoc-gen-connecpy
+   
+   # Make executable
+   chmod +x protoc-gen-connecpy
+   
+   # Move to a directory in PATH
+   sudo mv protoc-gen-connecpy /usr/local/bin/
+   # Or for user-only installation:
+   # mkdir -p ~/.local/bin
+   # mv protoc-gen-connecpy ~/.local/bin/
+   # Make sure ~/.local/bin is in your PATH
+   ```
+
+   **Windows (PowerShell):**
+   ```powershell
+   # Rename the file
+   Rename-Item protoc-gen-connecpy-windows-*.exe protoc-gen-connecpy.exe
+   
+   # Move to a directory in PATH, for example:
+   Move-Item protoc-gen-connecpy.exe C:\Tools\
+   # Then add C:\Tools to your PATH environment variable:
+   # [System.Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";C:\Tools", "User")
+   ```
+
+3. **Verify installation:**
+   ```bash
+   # Check if the plugin is accessible
+   which protoc-gen-connecpy  # Linux/macOS
+   where protoc-gen-connecpy  # Windows
+   
+   # Test with protoc (requires a .proto file)
+   protoc --connecpy_out=. --connecpy_opt=paths=source_relative test.proto
+   ```
+
+#### Option 3: Install with Go
+If you have Go installed, you can install the plugin directly:
 
 ```sh
 go install github.com/i2y/connecpy/v2/protoc-gen-connecpy@latest
 ```
+
+This will install the binary to `$GOPATH/bin` (or `$HOME/go/bin` if GOPATH is not set). Make sure this directory is in your PATH.
 
 ### Install the Python package
 
@@ -56,6 +119,29 @@ To run the server, you'll need one of the following: [Uvicorn](https://www.uvico
 ## Generate and run
 
 Use the protoc plugin to generate connecpy server and client code.
+
+### Using Buf (v2) - Recommended
+
+Create a `buf.gen.yaml` file:
+
+```yaml
+version: v2
+plugins:
+  - remote: buf.build/protocolbuffers/python
+    out: gen
+  - remote: buf.build/protocolbuffers/pyi
+    out: gen
+  - local: protoc-gen-connecpy
+    out: gen
+```
+
+Then run:
+
+```sh
+buf generate
+```
+
+### Using protoc directly
 
 ```sh
 protoc --python_out=./ --pyi_out=./ --connecpy_out=./ ./haberdasher.proto

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,6 @@ detect_os() {
         darwin)
             echo "darwin"
             ;;
-        mingw*|msys*|cygwin*)
-            echo "windows"
-            ;;
         *)
             print_error "Unsupported operating system: $OS"
             exit 1
@@ -98,13 +95,8 @@ main() {
     # Remove 'v' prefix from version for filename
     VERSION_NUM="${VERSION#v}"
     
-    if [ "$OS" = "windows" ]; then
-        ARCHIVE_NAME="${BINARY_NAME}_${VERSION_NUM}_${OS}_${ARCH}.zip"
-        ARCHIVE_TYPE="zip"
-    else
-        ARCHIVE_NAME="${BINARY_NAME}_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
-        ARCHIVE_TYPE="tar.gz"
-    fi
+    ARCHIVE_NAME="${BINARY_NAME}_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
+    ARCHIVE_TYPE="tar.gz"
     
     DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/${ARCHIVE_NAME}"
     
@@ -122,16 +114,9 @@ main() {
     
     # Extract archive
     print_info "Extracting archive..."
-    if [ "$ARCHIVE_TYPE" = "zip" ]; then
-        if ! unzip -q "$TMP_DIR/$ARCHIVE_NAME" -d "$TMP_DIR"; then
-            print_error "Failed to extract zip archive"
-            exit 1
-        fi
-    else
-        if ! tar -xzf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"; then
-            print_error "Failed to extract tar.gz archive"
-            exit 1
-        fi
+    if ! tar -xzf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"; then
+        print_error "Failed to extract tar.gz archive"
+        exit 1
     fi
     
     # Find the binary (it should be named protoc-gen-connecpy)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+REPO="i2y/connecpy"
+BINARY_NAME="protoc-gen-connecpy"
+DEFAULT_INSTALL_DIR="/usr/local/bin"
+
+# Parse command line arguments and environment variables
+INSTALL_DIR="${PROTOC_GEN_CONNECPY_INSTALL:-$DEFAULT_INSTALL_DIR}"
+VERSION="${VERSION:-latest}"
+
+# Function to print colored output
+print_error() {
+    echo -e "${RED}Error: $1${NC}" >&2
+}
+
+print_success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+print_info() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+# Detect OS
+detect_os() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$OS" in
+        linux)
+            echo "linux"
+            ;;
+        darwin)
+            echo "darwin"
+            ;;
+        mingw*|msys*|cygwin*)
+            echo "windows"
+            ;;
+        *)
+            print_error "Unsupported operating system: $OS"
+            exit 1
+            ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        x86_64|amd64)
+            echo "amd64"
+            ;;
+        aarch64|arm64)
+            echo "arm64"
+            ;;
+        *)
+            print_error "Unsupported architecture: $ARCH"
+            exit 1
+            ;;
+    esac
+}
+
+# Get the latest version from GitHub
+get_latest_version() {
+    curl -sL "https://api.github.com/repos/$REPO/releases/latest" | \
+        grep '"tag_name":' | \
+        sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# Main installation function
+main() {
+    print_info "Installing protoc-gen-connecpy..."
+    
+    # Detect system
+    OS=$(detect_os)
+    ARCH=$(detect_arch)
+    
+    print_info "Detected system: $OS/$ARCH"
+    
+    # Get version
+    if [ "$VERSION" = "latest" ]; then
+        VERSION=$(get_latest_version)
+        if [ -z "$VERSION" ]; then
+            print_error "Failed to get latest version"
+            exit 1
+        fi
+    fi
+    
+    print_info "Installing version: $VERSION"
+    
+    # Construct download URL
+    # Remove 'v' prefix from version for filename
+    VERSION_NUM="${VERSION#v}"
+    
+    if [ "$OS" = "windows" ]; then
+        ARCHIVE_NAME="${BINARY_NAME}_${VERSION_NUM}_${OS}_${ARCH}.zip"
+        ARCHIVE_TYPE="zip"
+    else
+        ARCHIVE_NAME="${BINARY_NAME}_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
+        ARCHIVE_TYPE="tar.gz"
+    fi
+    
+    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/${ARCHIVE_NAME}"
+    
+    print_info "Downloading from: $DOWNLOAD_URL"
+    
+    # Create temporary directory
+    TMP_DIR=$(mktemp -d)
+    trap "rm -rf $TMP_DIR" EXIT
+    
+    # Download archive
+    if ! curl -sL -o "$TMP_DIR/$ARCHIVE_NAME" "$DOWNLOAD_URL"; then
+        print_error "Failed to download archive from $DOWNLOAD_URL"
+        exit 1
+    fi
+    
+    # Extract archive
+    print_info "Extracting archive..."
+    if [ "$ARCHIVE_TYPE" = "zip" ]; then
+        if ! unzip -q "$TMP_DIR/$ARCHIVE_NAME" -d "$TMP_DIR"; then
+            print_error "Failed to extract zip archive"
+            exit 1
+        fi
+    else
+        if ! tar -xzf "$TMP_DIR/$ARCHIVE_NAME" -C "$TMP_DIR"; then
+            print_error "Failed to extract tar.gz archive"
+            exit 1
+        fi
+    fi
+    
+    # Find the binary (it should be named protoc-gen-connecpy)
+    if [ ! -f "$TMP_DIR/$BINARY_NAME" ]; then
+        print_error "Binary not found in archive"
+        exit 1
+    fi
+    
+    # Make binary executable
+    chmod +x "$TMP_DIR/$BINARY_NAME"
+    
+    # Create install directory if it doesn't exist
+    if [ ! -d "$INSTALL_DIR" ]; then
+        print_info "Creating directory: $INSTALL_DIR"
+        if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+            print_info "Need sudo to create $INSTALL_DIR"
+            sudo mkdir -p "$INSTALL_DIR"
+        fi
+    fi
+    
+    # Install binary
+    print_info "Installing to: $INSTALL_DIR/$BINARY_NAME"
+    
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$TMP_DIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+    else
+        print_info "Need sudo to install to $INSTALL_DIR"
+        sudo mv "$TMP_DIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+    fi
+    
+    # Verify installation
+    if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
+        print_success "✅ Successfully installed $BINARY_NAME $VERSION to $INSTALL_DIR"
+        
+        # Check if it's in PATH
+        if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+            print_info "You can now use: protoc --connecpy_out=. your_service.proto"
+        else
+            print_info "Note: $INSTALL_DIR is not in your PATH"
+            print_info "To use $BINARY_NAME from anywhere, add this directory to your PATH:"
+            print_info "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc"
+            print_info "  source ~/.bashrc"
+            print_info ""
+            print_info "Or you can use the full path: $INSTALL_DIR/$BINARY_NAME"
+        fi
+    else
+        print_error "Installation failed - binary not found at $INSTALL_DIR/$BINARY_NAME"
+        exit 1
+    fi
+}
+
+# Show usage
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    cat <<EOF
+Install protoc-gen-connecpy
+
+Usage:
+    curl -sSL https://i2y.github.io/connecpy/install.sh | bash
+    curl -sSL https://i2y.github.io/connecpy/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/.local/bin bash
+    curl -sSL https://i2y.github.io/connecpy/install.sh | VERSION=v2.1.0 bash
+
+Environment Variables:
+    PROTOC_GEN_CONNECPY_INSTALL  Installation directory (default: /usr/local/bin)
+    VERSION                       Version to install (default: latest)
+
+Options:
+    -h, --help                    Show this help message
+
+Examples:
+    # Install latest version to default location
+    curl -sSL https://i2y.github.io/connecpy/install.sh | bash
+    
+    # Install to user directory
+    curl -sSL https://i2y.github.io/connecpy/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/bin bash
+    
+    # Install specific version
+    curl -sSL https://i2y.github.io/connecpy/install.sh | VERSION=v2.0.0 bash
+
+EOF
+    exit 0
+fi
+
+# Run main installation
+main

--- a/install.sh
+++ b/install.sh
@@ -189,9 +189,9 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 Install protoc-gen-connecpy
 
 Usage:
-    curl -sSL https://i2y.github.io/connecpy/install.sh | bash
-    curl -sSL https://i2y.github.io/connecpy/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/.local/bin bash
-    curl -sSL https://i2y.github.io/connecpy/install.sh | VERSION=v2.1.0 bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/.local/bin bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | VERSION=v2.1.0 bash
 
 Environment Variables:
     PROTOC_GEN_CONNECPY_INSTALL  Installation directory (default: /usr/local/bin)
@@ -202,13 +202,13 @@ Options:
 
 Examples:
     # Install latest version to default location
-    curl -sSL https://i2y.github.io/connecpy/install.sh | bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | bash
     
     # Install to user directory
-    curl -sSL https://i2y.github.io/connecpy/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/bin bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | PROTOC_GEN_CONNECPY_INSTALL=\$HOME/bin bash
     
     # Install specific version
-    curl -sSL https://i2y.github.io/connecpy/install.sh | VERSION=v2.0.0 bash
+    curl -sSL https://raw.githubusercontent.com/i2y/connecpy/main/install.sh | VERSION=v2.0.0 bash
 
 EOF
     exit 0


### PR DESCRIPTION
## What
- Add install.sh script for easy protoc-gen-connecpy installation
- Enhance README with detailed installation instructions including the quick install option
- Support automatic platform detection (Linux/macOS, AMD64/ARM64)

## Why
- Simplify CI/CD setup: One-line installation without Go runtime, faster than go install
- Enterprise-friendly: Ideal for centralized protobuf repositories with GitHub Actions automation when an organization can't use BSR for some reason unfortunately.