### PR TITLE
chore: simplify wheel generation thanks to fixed uv

### DIFF
--- a/protoc-gen-connecpy/pyproject.toml
+++ b/protoc-gen-connecpy/pyproject.toml
@@ -7,8 +7,11 @@ requires-python = ">= 3.10"
 readme = "README.md"
 license-files = ["LICENSE"]
 
+[tool.uv]
+dev-dependencies = ["wheel"]
+
 [build-system]
-requires = ["uv_build>=0.7.21,<0.9.0"]
+requires = ["uv_build>=0.8.13,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/protoc-gen-connecpy/scripts/generate_wheels.py
+++ b/protoc-gen-connecpy/scripts/generate_wheels.py
@@ -45,7 +45,6 @@ def main() -> None:
         subprocess.run(["uv", "build", "--wheel"], check=True)  # noqa: S607
         dist_dir = Path(__file__).parent / ".." / "dist"
         built_wheel = next(dist_dir.glob("*-py3-none-any.whl"))
-        # TODO(anuraaga): Simplify after https://github.com/astral-sh/uv/pull/15400
 
         subprocess.run(  # noqa: S603
             [

--- a/protoc-gen-connecpy/scripts/generate_wheels.py
+++ b/protoc-gen-connecpy/scripts/generate_wheels.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -12,7 +13,7 @@ def main() -> None:
         if artifact["type"] != "Binary":
             continue
         # Check https://go.dev/wiki/MinimumRequirements#operating-systems for
-        # minimum OS versions
+        # minimum OS versions, especially MacOS
         platform = ""
         match artifact["goos"]:
             case "darwin":
@@ -22,15 +23,11 @@ def main() -> None:
                     case "arm64":
                         platform = "macosx_11_0_arm64"
             case "linux":
-                # While manylinux1 is considered legacy versus the more
-                # precise manylinux_x_y, our binaries are statically compiled
-                # so we go with it for maximum compatibility. We also use the
-                # same wheel for musl.
                 match artifact["goarch"]:
                     case "amd64":
-                        platform = "manylinux1_x86_64"
+                        platform = "manylinux2_17_x86_64.manylinux_2014_x86_64.musllinux_1_1_x86_64"
                     case "arm64":
-                        platform = "manylinux1_aarch64"
+                        platform = "manylinux2_17_aarch64.manylinux_2014_aarch64.musllinux_1_1_aarch64"
             case "windows":
                 match artifact["goarch"]:
                     case "amd64":
@@ -49,14 +46,20 @@ def main() -> None:
         dist_dir = Path(__file__).parent / ".." / "dist"
         built_wheel = next(dist_dir.glob("*-py3-none-any.whl"))
         # TODO(anuraaga): Simplify after https://github.com/astral-sh/uv/pull/15400
-        base_name = built_wheel.name[: -len("-py3-none-any.whl")]
-        wheel_name = f"{base_name}-py3-none-{platform}.whl"
-        built_wheel.rename(dist_dir / wheel_name)
-        if platform.startswith("manylinux1"):
-            shutil.copyfile(
-                dist_dir / wheel_name,
-                dist_dir / wheel_name.replace("manylinux1", "musllinux_1_0"),
-            )
+
+        subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "wheel",
+                "tags",
+                "--remove",
+                "--platform-tag",
+                platform,
+                built_wheel,
+            ],
+            check=True,
+        )
 
 
 if __name__ == "__main__":

--- a/protoc-gen-connecpy/uv.lock
+++ b/protoc-gen-connecpy/uv.lock
@@ -6,3 +6,22 @@ requires-python = ">=3.10"
 name = "protoc-gen-connecpy"
 version = "2.2.0"
 source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "wheel" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "wheel" }]
+
+[[package]]
+name = "wheel"
+version = "0.45.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545, upload-time = "2024-11-23T00:18:23.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494, upload-time = "2024-11-23T00:18:21.207Z" },
+]


### PR DESCRIPTION
Now that uv's fixed and generates correct wheels, we can use the `wheel` command to tag instead of manual operation.

Also went ahead and just matched the linux tags for uv rather than using the very legacy manylinux1, glibc 2.17 is ~10 years old anyways so it should be fine, especially if it's good enough for uv.

https://pypi.org/project/uv/#files

@i2y By the way, for actual publishing, any ideas on it?

https://github.com/i2y/connecpy/pull/123#issue-3340071859

> I didn't wire up to the release flow since I guess we would need your PyPi access restored to make a new package? Let me know any thoughts on what we can do for it.