### PR TITLE
fix: fix typo in manylinux platform tag for protoc wheels

### DIFF
--- a/protoc-gen-connecpy/scripts/generate_wheels.py
+++ b/protoc-gen-connecpy/scripts/generate_wheels.py
@@ -25,9 +25,9 @@ def main() -> None:
             case "linux":
                 match artifact["goarch"]:
                     case "amd64":
-                        platform = "manylinux2_17_x86_64.manylinux_2014_x86_64.musllinux_1_1_x86_64"
+                        platform = "manylinux_2_17_x86_64.manylinux_2014_x86_64.musllinux_1_1_x86_64"
                     case "arm64":
-                        platform = "manylinux2_17_aarch64.manylinux_2014_aarch64.musllinux_1_1_aarch64"
+                        platform = "manylinux_2_17_aarch64.manylinux_2014_aarch64.musllinux_1_1_aarch64"
             case "windows":
                 match artifact["goarch"]:
                     case "amd64":


### PR DESCRIPTION
##  What
Fixed a typo in the manylinux platform tag: manylinux2_17 → manylinux_2_17

## Why
PyPI was rejecting wheels with the invalid platform tag manylinux2_17_xxx. The correct format is manylinux_2_17_xxx with an underscore between "manylinux" and the version number.