### PR TITLE
fix: avoid newer any pack method and specify min protobuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.3.0"
 description = "Server library and client library for the Connect Protocol"
 authors = [{ name = "Connecpy authors" }]
 requires-python = ">= 3.10"
-dependencies = ["httpx", "protobuf"]
+dependencies = ["httpx", "protobuf>=5.28"]
 readme = "README.md"
 license-files = ["LICENSE"]
 keywords = [

--- a/src/connecpy/exceptions.py
+++ b/src/connecpy/exceptions.py
@@ -3,7 +3,7 @@ __all__ = ["ConnecpyException"]
 
 from collections.abc import Iterable, Sequence
 
-from google.protobuf.any import Any, pack
+from google.protobuf.any_pb2 import Any
 from google.protobuf.message import Message
 
 from .code import Code
@@ -34,7 +34,9 @@ class ConnecpyException(Exception):
         self._message = message
 
         self._details = (
-            [m if isinstance(m, Any) else pack(m) for m in details] if details else ()
+            [m if isinstance(m, Any) else pack_any(m) for m in details]
+            if details
+            else ()
         )
 
     @property
@@ -48,3 +50,9 @@ class ConnecpyException(Exception):
     @property
     def details(self) -> Sequence[Any]:
         return self._details
+
+
+def pack_any(msg: Message) -> Any:
+    any_msg = Any()
+    any_msg.Pack(msg=msg, type_url_prefix="type.googleapis.com/")
+    return any_msg

--- a/test/test_details.py
+++ b/test/test_details.py
@@ -1,12 +1,11 @@
 from typing import NoReturn
 
 import pytest
-from google.protobuf.any import pack
 from google.protobuf.struct_pb2 import Struct, Value
 from httpx import ASGITransport, AsyncClient, Client, WSGITransport
 
 from connecpy.code import Code
-from connecpy.exceptions import ConnecpyException
+from connecpy.exceptions import ConnecpyException, pack_any
 from example.haberdasher_connecpy import (
     Haberdasher,
     HaberdasherASGIApplication,
@@ -26,7 +25,7 @@ def test_details_sync() -> None:
                 "Resource exhausted",
                 details=[
                     Struct(fields={"animal": Value(string_value="bear")}),
-                    pack(Struct(fields={"color": Value(string_value="red")})),
+                    pack_any(Struct(fields={"color": Value(string_value="red")})),
                 ],
             )
 
@@ -58,7 +57,7 @@ async def test_details_async() -> None:
                 "Resource exhausted",
                 details=[
                     Struct(fields={"animal": Value(string_value="bear")}),
-                    pack(Struct(fields={"color": Value(string_value="red")})),
+                    pack_any(Struct(fields={"color": Value(string_value="red")})),
                 ],
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
-    { name = "protobuf" },
+    { name = "protobuf", specifier = ">=5.28" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
- I realized `.any` package is pretty new and restricts protobuf versions so replaced it
- Currently, 5.28+ is required as it is the first version to support `bytearray` passed to parse methods. I think it's fine to set it as the minimum version since it is safe to upgrade from any 5.x to the latest 5.x
  - If there is demand for 4.x in the future, we could look into what is required for it. It may be more than just the above, I didn't check it yet