### PR TITLE
fix: sanitize method names that match python keywords

### DIFF
--- a/protoc-gen-connecpy/generator/generator.go
+++ b/protoc-gen-connecpy/generator/generator.go
@@ -139,10 +139,27 @@ func GenerateConnecpyFile(fd protoreflect.FileDescriptor, conf Config) (*plugin.
 	return resp, nil
 }
 
+func sanitizePythonName(name string) string {
+	// https://docs.python.org/3/reference/lexical_analysis.html#keywords
+	// with bytes and str
+	switch name {
+	case "False", "await", "else", "import", "pass",
+		"None", "break", "except", "in", "raise",
+		"True", "class", "finally", "is", "return",
+		"and", "continue", "for", "lambda", "try",
+		"as", "def", "from", "nonlocal", "while",
+		"assert", "del", "global", "not", "with",
+		"async", "elif", "if", "or", "yield",
+		"bytes", "str":
+		return name + "_"
+	}
+	return name
+}
+
 func pythonMethodName(name string, conf Config) string {
 	switch conf.Naming {
 	case NamingGoogle:
-		return name
+		return sanitizePythonName(name)
 	case NamingPEP:
 		if len(name) <= 1 {
 			return strings.ToLower(name)
@@ -158,7 +175,7 @@ func pythonMethodName(name string, conf Config) string {
 				buf = append(buf, byte(name[i]))
 			}
 		}
-		return string(buf)
+		return sanitizePythonName(string(buf))
 	default:
 		panic("Unknown naming, this is a bug in protoc-gen-connecpy")
 	}

--- a/protoc-gen-connecpy/generator/generator_test.go
+++ b/protoc-gen-connecpy/generator/generator_test.go
@@ -119,9 +119,10 @@ func TestGenerateConnecpyFile(t *testing.T) {
 
 func TestGenerate(t *testing.T) {
 	tests := []struct {
-		name    string
-		req     *pluginpb.CodeGeneratorRequest
-		wantErr bool
+		name        string
+		req         *pluginpb.CodeGeneratorRequest
+		wantStrings []string
+		wantErr     bool
 	}{
 		{
 			name: "empty request",
@@ -153,6 +154,12 @@ func TestGenerate(t *testing.T) {
 										InputType:  proto.String(".otherpackage.OtherRequest"),
 										OutputType: proto.String(".otherpackage.OtherResponse"),
 									},
+									// Reserved keyword
+									{
+										Name:       proto.String("Try"),
+										InputType:  proto.String(".otherpackage.OtherRequest"),
+										OutputType: proto.String(".otherpackage.OtherResponse"),
+									},
 								},
 							},
 						},
@@ -179,7 +186,8 @@ func TestGenerate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:     false,
+			wantStrings: []string{"def try_(self"},
 		},
 	}
 
@@ -196,6 +204,11 @@ func TestGenerate(t *testing.T) {
 				}
 				if len(resp.GetFile()) == 0 {
 					t.Error("Generate() returned no files")
+				}
+				for _, s := range tt.wantStrings {
+					if !strings.Contains(resp.GetFile()[0].GetContent(), s) {
+						t.Errorf("Generate() missing expected string: %v", s)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
Fixes #146 