### PR TITLE
fix: copy file with permissions for wheel

### DIFF
--- a/protoc-gen-connecpy/scripts/generate_wheels.py
+++ b/protoc-gen-connecpy/scripts/generate_wheels.py
@@ -41,7 +41,7 @@ def main() -> None:
         bin_dir = Path(__file__).parent / ".." / "out" / "bin"
         shutil.rmtree(bin_dir, ignore_errors=True)
         bin_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(exe_path, bin_dir / exe_path.name)
+        shutil.copy2(exe_path, bin_dir / exe_path.name)
         subprocess.run(["uv", "build", "--wheel"], check=True)  # noqa: S607
         dist_dir = Path(__file__).parent / ".." / "dist"
         built_wheel = next(dist_dir.glob("*-py3-none-any.whl"))


### PR DESCRIPTION
I realized the wheel binaries didn't have executable bit set. Since they're not generally invoked manually but through subprocess which doesn't need it, I don't think it affects code generation but good to fix anyways.